### PR TITLE
Feature stepdef params

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,7 @@
       http://www.scala-lang.org
          
    gwen
-      Version 1.0.0-2f05b9e99b8e93aa7d7369727159f07525e25d42
+      Version 1.0.0-3a81195a48facdefac40fd0850b18ad1e13b9800
       Copyright (c) 2014-2015 Branko Juric, Brady Wood 
       Apache License, Version 2.0
       https://github.com/gwen-interpreter/gwen/LICENSE

--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,7 @@
       http://www.scala-lang.org
          
    gwen
-      Version 1.0.0-3a81195a48facdefac40fd0850b18ad1e13b9800
+      Version 1.0.0-a0015477d3c54e28deb914eaf111af3c87205943
       Copyright (c) 2014-2015 Branko Juric, Brady Wood 
       Apache License, Version 2.0
       https://github.com/gwen-interpreter/gwen/LICENSE

--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,7 @@
       http://www.scala-lang.org
          
    gwen
-      Version 1.0.0-a0015477d3c54e28deb914eaf111af3c87205943
+      Version 1.0.0-9b2adfc0ff971f1a2f6cee1e6d9f8c3a742cbfb2
       Copyright (c) 2014-2015 Branko Juric, Brady Wood 
       Apache License, Version 2.0
       https://github.com/gwen-interpreter/gwen/LICENSE

--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,7 @@
       http://www.scala-lang.org
          
    gwen
-      Version 1.0.0-9b2adfc0ff971f1a2f6cee1e6d9f8c3a742cbfb2
+      Version 1.0.0-0e5ae39578bf1b90c9d087be2421b50821e13020
       Copyright (c) 2014-2015 Branko Juric, Brady Wood 
       Apache License, Version 2.0
       https://github.com/gwen-interpreter/gwen/LICENSE

--- a/features/floodio/FloodIO.meta
+++ b/features/floodio/FloodIO.meta
@@ -25,49 +25,48 @@
   @StepDef
   Scenario: I launch the floodio challenge
       Given I navigate to "https://challengers.flood.io/start"
+      
+  @StepDef
+  Scenario: the <page-name> page has loaded
+      Given I wait until the heading is displayed
+       Then I am on the $<page-name> page
   
   @StepDef 
   Scenario: I should be on the start page
-      Given I wait until the heading is displayed
-       Then I am on the start page
-        And the heading should be "Welcome to our Script Challenge"
+      Given the start page has loaded
+       Then the heading should be "Welcome to our Script Challenge"
         And the Start button can be located by name "commit"
 
   @StepDef
   Scenario: I should be on the step 2 page
-      Given I wait until the heading is displayed
-       Then I am on the step 2 page
-        And the heading should be "Step 2"
+      Given the step 2 page has loaded
+       Then the heading should be "Step 2"
         And the how old are you dropdown can be located by id "challenger_age"
 
   @StepDef
   Scenario: I should be on the step 3 page
-      Given I wait until the heading is displayed
-       Then I am on the step 3 page
-        And the heading should be "Step 3"
+      Given the step 3 page has loaded
+       Then the heading should be "Step 3"
         And the largest order value is defined by javascript "Math.max.apply(Math, $.map($('.radio'), function(x) { return parseInt($(x).text()); }))"
         And the largest order input field can be located by id "challenger_largest_order"
         And the largest order radio button can be located by javascript "$('.radio:contains(${the largest order value}) input').get(0);"
       
   @StepDef  
   Scenario: I should be on the step 4 page
-      Given I wait until the heading is displayed
-       Then I am on the step 4 page
-        And the heading should be "Step 4"
+      Given the step 4 page has loaded
+       Then the heading should be "Step 4"
         
   @StepDef
   Scenario: I should be on the step 5 page
-      Given I wait until the heading is displayed
-       Then I am on the step 5 page
-        And the heading should be "Step 5"
+      Given the step 5 page has loaded
+       Then the heading should be "Step 5"
         And the one time token can be located by css selector ".token"
         And the one time token field can be located by id "challenger_one_time_token"
         
   @StepDef
   Scenario: I should be on the challenge completed page
-      Given I wait until the heading is displayed
-       Then I am on the challenge completed page
-        And the heading should be "You're Done!"
+      Given the challenge completed page has loaded
+       Then the heading should be "You're Done!"
         And the lead paragraph can be located by class name "lead"
      
   @StepDef

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -123,7 +123,7 @@ trait WebEngine extends EvalEngine[WebEnvContext] with WebElementLocator with Sy
         
       case r"""(.+?)$element should( not)?$negation (be|contain|match regex|match xpath)$operator "(.*?)"$$$expression""" => { 
         if (element == "I") undefinedStepError(step)
-        val actual = env.getBoundValue(element)
+        val actual = env.getBoundReferenceValue(element)
         env.execute {
           compare(element, expression, actual, operator, Option(negation).isDefined, env)
         }
@@ -132,19 +132,19 @@ trait WebEngine extends EvalEngine[WebEnvContext] with WebElementLocator with Sy
       case r"""(.+?)$element should( not)?$negation (be|contain|match regex|match xpath)$operator (.+?)$$$attribute""" => {
         if (element == "I") undefinedStepError(step)
         val expected = env.getAttribute(attribute)
-        val actual = env.getBoundValue(element)
+        val actual = env.getBoundReferenceValue(element)
         env.execute {
           compare(element, expected, actual, operator, Option(negation).isDefined, env)
         }
       }
       
       case r"""I capture the (text|node|nodeset)$targetType in (.+?)$source by xpath "(.+?)"$expression as (.+?)$$$name""" => {
-        val src = env.getBoundValue(source)
+        val src = env.getBoundReferenceValue(source)
         env.featureScope.set(name, env.execute(env.evaluateXPath(expression, src, env.XMLNodeType.withName(targetType))).getOrElse(s"$$[xpath:$expression]"))
       }
       
       case r"""I capture the text in (.+?)$source by regex "(.+?)"$expression as (.+?)$$$name""" => {
-        val src = env.getBoundValue(source)
+        val src = env.getBoundReferenceValue(source)
         env.featureScope.set(name, env.execute(env.extractByRegex(expression, src)).getOrElse(s"$$[regex:$expression"))
       }
       
@@ -155,10 +155,10 @@ trait WebEngine extends EvalEngine[WebEnvContext] with WebElementLocator with Sy
         env.featureScope.set(name, env.execute(env.withWebDriver(_.getCurrentUrl())).getOrElse("$[currentUrl]"))
       
       case r"""I capture (.+?)$element as (.+?)$attribute""" =>
-        env.featureScope.set(attribute, env.getBoundValue(element))
+        env.featureScope.set(attribute, env.getBoundReferenceValue(element))
         
       case r"""I capture (.+?)$element""" =>
-        env.featureScope.set(element, env.getBoundValue(element))
+        env.featureScope.set(element, env.getBoundReferenceValue(element))
         
       case r"""I wait for (.+?)$element text for (.+?)$seconds second(?:s?)""" =>  {
         val elementBinding = env.getLocatorBinding(element)


### PR DESCRIPTION
Implemented support for StepDef parameters. Parameters can now be passed inline instead of through other attributes. 

Parameters are declared in StepDefs using the ```<name>``` syntax and dereferenced with ```$<name>```

For example, the following StepDef can be used to assert that you should be on a page 

```
@StepDef
Scenario: I should be on the <page name> page
    Given I wait until the heading is displayed
     Then I am on the $<page name> page
      And the heading should be "$<page name>"
```
   
Once defined in meta, features can then call it to assert that they are on specific pages as follows:

```
Then I should be on the Step 2 page
Then I should be on the Step 3 page
Then I should be on the Dashboard page
```
This feature will help eliminate a lot of redundancies and make composing custom DSLs much easier.

