### PR TITLE
Ability to override selenium implementation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,3 +84,4 @@ First gwen-web release.
     - gwen.web.accept.untrusted.certs
     - gwen.web.suppress.images (firefox only)
     - gwen.web.chrome.extensions (chrome only)
+  - Interchangeable selenium implementation through SELENIUM_HOME environment variable

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Key Features
 - Cross browser support
 - Remote web driver support
 - Screenshot capture and slideshow playback
+- Interchangeable Selenium implementation
+  - See [Changing the selenium version](CHEATSHEET#changing-the-selenium-version)  
  
 Core Requirements
 -----------------

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -74,6 +74,17 @@ exit|quit|bye
   Press tab key at any time for tab completion
 ```
 
+Changing the Selenium version
+-----------------------------
+By default, gwen-web uses the selenium implementation bundled in the 
+distribution (see selenium JARs in the lib dir). If you would like to use a 
+different version of selenium instead, then you can download the 
+`selenium-java` ZIP distribution you desire from the 
+[selenium downloads](http://www.seleniumhq.org/download/) page and unpack it 
+to a location on your drive and then set the `SELENIUM_HOME` environment 
+variable to point to that location. Gwen will then use that selenium version 
+when it is next invoked.
+
 Configuration Settings
 ----------------------
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -16,3 +16,6 @@ No, gwen-web uses page scopes to emulate page objects and does away with
 development and compilation altogether through a [prescribed DSL](CHEATSHEET.md#supported-dsl). 
 - See also: [Page Objects Begone](https://warpedjavaguy.wordpress.com/2014/08/27/page-objects-begone/)
 
+Can I change the selenium implementation used by gwen-web?
+----------------------------------------------------------
+Yes, see [Changing the Selenium version](CHEATSHEET#changing-the-selenium-version).

--- a/package.sbt
+++ b/package.sbt
@@ -40,3 +40,12 @@ mappings in Universal <++= (com.typesafe.sbt.packager.Keys.makeBatScript in Univ
     s <- script.toSeq
   } yield s -> ("bin/gwen.bat") 
 }
+
+val BashClasspathPattern = "declare -r app_classpath=\"(.*)\"\n".r
+
+bashScriptDefines := bashScriptDefines.value.map {
+  case BashClasspathPattern(classpath) => "declare -r app_classpath=\"$SELENIUM_HOME/*:$SELENIUM_HOME/libs/*:" + classpath + "\"\n"
+  case _@entry => entry
+}
+
+batScriptExtraDefines += """set "APP_CLASSPATH=%SELENIUM_HOME%\*;%SELENIUM_HOME%\libs\*;%APP_CLASSPATH%""""

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -56,6 +56,8 @@ import scala.collection.JavaConverters._
   */
 class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) extends EnvContext(options, scopes) with WebElementLocator with DriverManager with RegexSupport with XPathSupport {
 
+   Try(logger.info(s"SELENIUM_HOME = ${sys.env("SELENIUM_HOME")}"))
+  
    /** Resets the current context and closes the web browser. */
   override def reset() {
     super.reset()


### PR DESCRIPTION
### Interchangeable Selenium implementations
This feature adds support for overriding the bundled selenium implementation.

By default, gwen-web uses the selenium implementation bundled in its 
distribution (see selenium JARs in the lib dir). If you would like to use a 
different version of selenium instead, then you can download the 
`selenium-java` ZIP distribution you desire from the 
[selenium downloads](http://www.seleniumhq.org/download/) page and unpack it 
to a location on your drive and then set the `SELENIUM_HOME` environment 
variable to point to that location. Gwen will then use that selenium version 
when it is next invoked.

This allows users to change the selenium version to match their target browsers 
without having to download multiple versions of gwen-web. It also means that 
we do not have to release a new version of gwen-web for every new selenium 
implementation version that is released (for as long as compatibility is preserved). 

### How does it work?
If the SELENIUM_HOME env variable is set, then the JARs in that
location are prepended to the classpath in the launch script (to
override the implementation bundled in gwen-web). 

---
** This feature has not been fully tested across all possible browser and selenium 
library versions and instabilities may occur with some combinations.