### PR TITLE
Context sensitive actions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+1.2.0
+=====
+Feb 16, 2016, 3:00 PM GMT+11 (AEDT)
+- Added support for performing actions on elements that are only 
+  available on a container element (that is; when the container element 
+  is moved to or hovered over with the mouse). This is supported through 
+  the following DSL:
+  - I <click|check|uncheck> <element> in <container>
+   
 1.1.1
 =====
 Feb 16, 2016, 12:43 PM GMT+11 (AEDT)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,13 @@
 1.2.0
 =====
-Feb 16, 2016, 3:00 PM GMT+11 (AEDT)
-- Added support for performing actions on elements that are only 
-  available on a container element (that is; when the container element 
-  is moved to or hovered over with the mouse). This is supported through 
-  the following DSL:
-  - I <click|check|uncheck> <element> in <container>
+Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
+- Added new DSLs for starting and closing browser sessions:
+  - I start a new browser session
+  - I close the current browser session
+- Added support for performing actions on context sensitive elements 
+  that are available only when another element is moved into first. 
+  This is supported through the following DSL: 
+  - I <click|check|uncheck> <element> of <context>
    
 1.1.1
 =====

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ specifications instead of code.
 
 [![Build Status](https://travis-ci.org/gwen-interpreter/gwen-web.svg?branch=master)](https://travis-ci.org/gwen-interpreter/gwen-web)
 
-- Current release: [1.1.1](https://github.com/gwen-interpreter/gwen-web/releases/latest)
+- Current release: [1.2.0](https://github.com/gwen-interpreter/gwen-web/releases/latest)
 - [Change log](CHANGELOG)
 
 Core Requirements

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1127,6 +1127,28 @@ a:visited {
 			</div>
 		</div>
 	</div>
+	
+	<em style="color:gray">Since v1.2.0</em>
+	<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_1">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> in <code>&lt;container&gt;</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_1">
+				<div class="panel-body">
+					Performs the specified action on an element in a container
+					<ul>
+						<li><code>&lt;element&gt;</code> = the element to perform the action on</li>
+						<li><code>&lt;container&gt;</code> = the container element</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
 
 	<hr>
 	<div class="well well-sm">

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1134,16 +1134,44 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_1">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
-					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> in <code>&lt;container&gt;</code>
+					I start a new browser session
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_1">
 				<div class="panel-body">
-					Performs the specified action on an element in a container
+					Closes the current browser session (if one is open) and starts a new one.
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_2">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
+					I close the current browser session
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_2">
+				<div class="panel-body">
+					Closes the current browser session (if one is open).
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_3">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_3">
+				<div class="panel-body">
+					Performs the specified action on a context sensitive element
 					<ul>
 						<li><code>&lt;element&gt;</code> = the element to perform the action on</li>
-						<li><code>&lt;container&gt;</code> = the container element</li>
+						<li><code>&lt;context&gt;</code> = the context element to move into (in order to activate &lt;element&gt;)</li>
 					</ul>
 				</div>
 			</div>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -190,9 +190,9 @@ I click <element>
 I check <element>
 I uncheck <element>
 I submit <element>
-I click <element> in <container>
-I check <element> in <container>
-I uncheck <element> in <container>
+I click <element> of <context>
+I check <element> of <context>
+I uncheck <element> of <context>
 I wait 1 second when <element> is clicked
 I wait 1 second when <element> is submitted
 I wait 1 second when <element> is checked
@@ -233,3 +233,5 @@ I base64 decode <reference> as <attribute>
 I base64 decode <reference>
 <step> until <condition>
 <step> while <condition>
+I start a new browser session
+I close the current browser session

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -187,9 +187,12 @@ I select "<text>" in <element> by value
 I select <reference> in <element>
 I select <reference> in <element> by value
 I click <element>
-I submit <element>
 I check <element>
 I uncheck <element>
+I submit <element>
+I click <element> in <container>
+I check <element> in <container>
+I uncheck <element> in <container>
 I wait 1 second when <element> is clicked
 I wait 1 second when <element> is submitted
 I wait 1 second when <element> is checked

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -417,11 +417,11 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         }
       }
         
-      case r"""I (click|check|uncheck)$action (.+?)$element in (.+?)$$$container""" => {
-        val containerBinding = env.getLocatorBinding(container)
+      case r"""I (click|check|uncheck)$action (.+?)$element of (.+?)$$$context""" => {
+        val contextBinding = env.getLocatorBinding(context)
         val elementBinding = env.getLocatorBinding(element)
         env.execute { 
-          env.performActionIn(action, elementBinding, containerBinding)
+          env.performActionIn(action, elementBinding, contextBinding)
         }
       }
       
@@ -441,6 +441,16 @@ trait WebEngine extends EvalEngine[WebEnvContext]
       
       case "I refresh the current page" => env.execute { 
         env.withWebDriver { _.navigate().refresh() }
+      }
+      
+      case "I start a new browser session" => env.execute {
+        env.quit()
+        env.withWebDriver { driver => // noop 
+        }
+      }
+      
+      case "I close the current browser session" => env.execute {
+        env.quit()
       }
       
       case _ => super.evaluate(step, env)

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -417,6 +417,14 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         }
       }
         
+      case r"""I (click|check|uncheck)$action (.+?)$element in (.+?)$$$container""" => {
+        val containerBinding = env.getLocatorBinding(container)
+        val elementBinding = env.getLocatorBinding(element)
+        env.execute { 
+          env.performActionIn(action, elementBinding, containerBinding)
+        }
+      }
+      
       case r"""I (click|submit|check|uncheck)$action (.+?)$$$element""" => {
         val elementBinding = env.getLocatorBinding(element)
         env.execute { 

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -538,18 +538,18 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
       action match {
         case "click" => webElement.click
         case "submit" => webElement.submit
-        case "check" if (!webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
-        case "uncheck" if (webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
+        case "check" => if (!webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
+        case "uncheck" => if (webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
       }
       bindAndWait(elementBinding.element, action, "true")
     }
   }
   
-  def performActionIn(action: String, elementBinding: LocatorBinding, containerBinding: LocatorBinding) {
-    withWebElement(action, containerBinding) { containerElement =>
+  def performActionIn(action: String, elementBinding: LocatorBinding, contextBinding: LocatorBinding) {
+    withWebElement(action, contextBinding) { contextElement =>
       withWebElement(action, elementBinding) { webElement =>
         withWebDriver { driver =>
-          var actions = new Actions(driver).moveToElement(containerElement).moveToElement(webElement)
+          var actions = new Actions(driver).moveToElement(contextElement).moveToElement(webElement)
           action match {
             case "click" => actions = actions.click
             case "check" => if (!webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -47,6 +47,7 @@ import gwen.errors._
 import scala.io.Source
 import scala.sys.process._
 import scala.collection.JavaConverters._
+import org.openqa.selenium.interactions.Actions
 
 /**
   * Defines the web environment context. This includes the configured selenium web
@@ -537,10 +538,27 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
       action match {
         case "click" => webElement.click
         case "submit" => webElement.submit
-        case "check" => if (!webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
-        case "uncheck" => if (webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
+        case "check" if (!webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
+        case "uncheck" if (webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
       }
       bindAndWait(elementBinding.element, action, "true")
+    }
+  }
+  
+  def performActionIn(action: String, elementBinding: LocatorBinding, containerBinding: LocatorBinding) {
+    withWebElement(action, containerBinding) { containerElement =>
+      withWebElement(action, elementBinding) { webElement =>
+        withWebDriver { driver =>
+          var actions = new Actions(driver).moveToElement(containerElement).moveToElement(webElement)
+          action match {
+            case "click" => actions = actions.click
+            case "check" => if (!webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)
+            case "uncheck" => if (webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)
+          }
+          actions.build.perform()
+        }
+        bindAndWait(elementBinding.element, action, "true")
+      }
     }
   }
   

--- a/src/test/scala/gwen/web/WebDslTest.scala
+++ b/src/test/scala/gwen/web/WebDslTest.scala
@@ -24,6 +24,8 @@ class WebDslTest extends FlatSpec {
     env.scopes.set("<condition>/javascript", "condition")
     env.scopes.set("<container>/locator", "id");
     env.scopes.set("<container>/locator/id", "id")
+    env.scopes.set("<context>/locator", "id")
+    env.scopes.set("<context>/locator/id", "id")
         
     val interpreter = new WebInterpreter
     withSetting("<name>", "name") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.1.1"
+git.baseVersion := "1.2.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
### Performing actions on context sensitive elements
This feature adds support for performing actions on context sensitive elements. This is now supported through the following DSL:

`I <click|check|uncheck> <element> of <context>`

For example, say you wanted to click an action button in a menu item that only becomes visible when you physically move into the menu item by hovering over it with the mouse. You can now do this as follows:

```gherkin
# define locators for the menu item and action button (as you normally would)
Given the menu item can be located by id "menu-item-id"
  And the action button can be located by id "action-button-id"

# then move into the menu item and click the action button
When I click the action button of the menu item
``` 
