### PR TITLE
Named browser sessions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+1.2.0
+=====
+Feb 16, 2016, 3:00 PM GMT+11 (AEDT)
+- Added support for performing actions on elements that are only 
+  available on a container element (that is; when the container element 
+  is moved to or hovered over with the mouse). This is supported through 
+  the following DSL:
+  - I <click|check|uncheck> <element> in <container>
+   
 1.1.1
 =====
 Feb 16, 2016, 12:43 PM GMT+11 (AEDT)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
 - Added new DSLs for starting and closing browser sessions:
   - I start a new browser session
   - I close the current browser session
+- Added new DSLs for supporting named browser sessions:
+  - I start a new browser session named "<name>"
+  - I close the browser session named "<name>"
+  - I switch to the browser session named "<name>"
 - Added support for performing actions on context sensitive elements 
   that are available only when another element is moved into first. 
   This is supported through the following DSL: 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,12 @@
 1.2.0
 =====
 Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
-- Added new DSLs for starting and closing browser sessions:
-  - I start a new browser session
-  - I close the current browser session
+- Added new DSLs closing the current browser session:
+  - I close the current browser
 - Added new DSLs for supporting named browser sessions:
-  - I start a new browser session named "<name>"
-  - I close the browser session named "<name>"
-  - I switch to the browser session named "<name>"
+  - I <have|start> a browser for <name>
+  - I close the browser for <name>
+  - I switch to <name>
 - Added support for performing actions on context sensitive elements 
   that are available only when another element is moved into first. 
   This is supported through the following DSL: 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 =====
 Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
 - Added the following DSLs for managing browser sessions:
+  - I start a new browser
   - I close the current browser
   - I start a browser for <session>
   - I close the browser for <session>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,11 @@
 1.2.0
 =====
 Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
-- Added new DSLs closing the current browser session:
+- Added the following DSLs for managing browser sessions:
   - I close the current browser
-- Added new DSLs for supporting named browser sessions:
-  - I <have|start> a browser for <name>
-  - I close the browser for <name>
-  - I switch to <name>
+  - I start a browser for <session>
+  - I close the browser for <session>
+  - I switch to <session>
 - Added support for performing actions on context sensitive elements 
   that are available only when another element is moved into first. 
   This is supported through the following DSL: 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,13 @@
 1.2.0
 =====
-Feb 16, 2016, 3:00 PM GMT+11 (AEDT)
-- Added support for performing actions on elements that are only 
-  available on a container element (that is; when the container element 
-  is moved to or hovered over with the mouse). This is supported through 
-  the following DSL:
-  - I <click|check|uncheck> <element> in <container>
+Feb 17, 2016, 12:07 AM GMT+11 (AEDT)
+- Added new DSLs for starting and closing browser sessions:
+  - I start a new browser session
+  - I close the current browser session
+- Added support for performing actions on context sensitive elements 
+  that are available only when another element is moved into first. 
+  This is supported through the following DSL: 
+  - I <click|check|uncheck> <element> of <context>
    
 1.1.1
 =====

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ specifications instead of code.
 
 [![Build Status](https://travis-ci.org/gwen-interpreter/gwen-web.svg?branch=master)](https://travis-ci.org/gwen-interpreter/gwen-web)
 
-- Current release: [1.1.1](https://github.com/gwen-interpreter/gwen-web/releases/latest)
+- Current release: [1.2.0](https://github.com/gwen-interpreter/gwen-web/releases/latest)
 - [Change log](CHANGELOG)
 
 Core Requirements

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1134,13 +1134,13 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_1">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
-					I start a new browser session
+					I close the current browser (if it is open)
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_1">
 				<div class="panel-body">
-					Closes the current browser session (if one is open) and starts a new one.
+					Closes the current browser session (if one is open).
 				</div>
 			</div>
 		</div>
@@ -1148,13 +1148,16 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_2">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
-					I close the current browser session
+					I &lt;have|start&gt; a browser for <code>&lt;name&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_2">
 				<div class="panel-body">
-					Closes the current browser session (if one is open).
+					Closes the current browser session (if one is open) and creates a new browser session with the given name.
+					<ul>
+						<li><code>&lt;name&gt;</code> = the unique name to assign to the new browser session</li>
+					</ul>
 				</div>
 			</div>
 		</div>
@@ -1162,15 +1165,15 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_3">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
-					I start a new browser session named &quot;<code>&lt;name&gt;</code>&quot;
+					I close the browser for <code>&lt;name&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_3">
 				<div class="panel-body">
-					Starts a new browser session with the given name. This can be used to create multiple uniquely named browser sessions.
+					Closes a named browser session (if one is open).
 					<ul>
-						<li><code>&lt;name&gt;</code> = the unique name to assign to the new browser session</li>
+						<li><code>&lt;name&gt;</code> = the name of the browser session to close</li>
 					</ul>
 				</div>
 			</div>
@@ -1179,15 +1182,15 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_4">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_4" aria-expanded="true" aria-controls="collapseOne">
-					I close the browser session named &quot;<code>&lt;name&gt;</code>&quot;
+					I switch to <code>&lt;name&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_4">
 				<div class="panel-body">
-					Closes a named browser session.
+					Switches to a named browser session (creates one if it does not exist). All actions performed after this execute in the named browser.
 					<ul>
-						<li><code>&lt;name&gt;</code> = the name of the browser session to close</li>
+						<li><code>&lt;name&gt;</code> = the name of the browser session to switch to</li>
 					</ul>
 				</div>
 			</div>
@@ -1196,28 +1199,11 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_5">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_5" aria-expanded="true" aria-controls="collapseOne">
-					I switch to the browser session named &quot;<code>&lt;name&gt;</code>&quot;
-					</a>
-				</h4>
-			</div>
-			<div id="collapse-1-2_5" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_5">
-				<div class="panel-body">
-					Passes control to the named browser session. All actions performed after this step execute in the named browser.
-					<ul>
-						<li><code>&lt;name&gt;</code> = the name of the browser session to switch to</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-		<div class="panel panel-default">
-			<div class="panel-heading" role="tab" id="dsl-1-2_6">
-				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_6" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
 					</a>
 				</h4>
 			</div>
-			<div id="collapse-1-2_6" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_6">
+			<div id="collapse-1-2_5" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_5">
 				<div class="panel-body">
 					Performs the specified action on a context sensitive element
 					<ul>
@@ -1228,10 +1214,6 @@ a:visited {
 			</div>
 		</div>
 	</div>
-	
-	
-  - I close the browser session named "<name>"
-  - I switch to the browser session named "<name>"
 
 	<hr>
 	<div class="well well-sm">

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1134,7 +1134,7 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_1">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
-					I close the current browser (if it is open)
+					I close the current browser
 					</a>
 				</h4>
 			</div>
@@ -1148,15 +1148,15 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_2">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
-					I &lt;have|start&gt; a browser for <code>&lt;name&gt;</code>
+					I start a browser for <code>&lt;session&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_2">
 				<div class="panel-body">
-					Closes the current browser session (if one is open) and creates a new browser session with the given name.
+					Closes the current browser session (if one is open) and starts a new browser session with the given name.
 					<ul>
-						<li><code>&lt;name&gt;</code> = the unique name to assign to the new browser session</li>
+						<li><code>&lt;session&gt;</code> = the unique name to assign to the new browser session</li>
 					</ul>
 				</div>
 			</div>
@@ -1165,7 +1165,7 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_3">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
-					I close the browser for <code>&lt;name&gt;</code>
+					I close the browser for <code>&lt;session&gt;</code>
 					</a>
 				</h4>
 			</div>
@@ -1173,7 +1173,7 @@ a:visited {
 				<div class="panel-body">
 					Closes a named browser session (if one is open).
 					<ul>
-						<li><code>&lt;name&gt;</code> = the name of the browser session to close</li>
+						<li><code>&lt;session&gt;</code> = the name of the browser session to close</li>
 					</ul>
 				</div>
 			</div>
@@ -1182,15 +1182,15 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_4">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_4" aria-expanded="true" aria-controls="collapseOne">
-					I switch to <code>&lt;name&gt;</code>
+					I switch to <code>&lt;session&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_4">
 				<div class="panel-body">
-					Switches to a named browser session (creates one if it does not exist). All actions performed after this execute in the named browser.
+					Switches to a named browser session (starts one if required). All actions performed after this execute in the named session.
 					<ul>
-						<li><code>&lt;name&gt;</code> = the name of the browser session to switch to</li>
+						<li><code>&lt;session&gt;</code> = the name of the browser session to switch to</li>
 					</ul>
 				</div>
 			</div>

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -51,12 +51,12 @@ a:visited {
 	<br>
 	<br>
 	<em style="color:gray">Since v1.0.0</em>
-	<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+	<div class="panel-group" id="accordion0" role="tablist" aria-multiselectable="true">
 		<!--- ---->
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-0">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-0" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-0" aria-expanded="true" aria-controls="collapseOne">
 					I am on the <code>&lt;page&gt;</code>
 					</a>
 				</h4>
@@ -75,7 +75,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-1" aria-expanded="true" aria-controls="collapseOne">
 					the url will be &quot;<code>&lt;url&gt;</code>&quot;
 					</a>
 				</h4>
@@ -94,7 +94,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-2">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-2" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-2" aria-expanded="true" aria-controls="collapseOne">
 					the url will be defined by &lt;property|setting&gt; &quot;<code>&lt;name&gt;</code>&quot;
 					</a>
 				</h4>
@@ -113,7 +113,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-3">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-3" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-3" aria-expanded="true" aria-controls="collapseOne">
 					I navigate to the <code>&lt;page&gt;</code>
 					</a>
 				</h4>
@@ -132,7 +132,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-4">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-4" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-4" aria-expanded="true" aria-controls="collapseOne">
 					I navigate to &quot;<code>&lt;url&gt;</code>&quot;
 					</a>
 				</h4>
@@ -151,7 +151,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-5">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-5" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-5" aria-expanded="true" aria-controls="collapseOne">
 					I scroll to the &lt;top|bottom&gt; of <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -170,7 +170,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-6">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-6" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-6" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;element&gt;</code> can be located by &lt;id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -190,7 +190,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-7">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-7" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-7" aria-expanded="true" aria-controls="collapseOne">
 					the page title &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -209,7 +209,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-8">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-8" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-8" aria-expanded="true" aria-controls="collapseOne">
 					the page title &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -228,7 +228,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-9">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-9" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-9" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;element&gt;</code> &lt;should|should not&gt; be &lt;displayed|hidden|checked|unchecked|enabled|disabled&gt;
 					</a>
 				</h4>
@@ -247,7 +247,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-10">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-10" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-10" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;element|attribute&gt;</code> &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -267,7 +267,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-11">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-11" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-11" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;element|attribute&gt;</code> &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -287,7 +287,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-12">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-12" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-12" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;dropdown&gt;</code> <code>&lt;text|value&gt;</code> &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -308,7 +308,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-13">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-13" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-13" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;dropdown&gt;</code> <code>&lt;text|value&gt;</code> &lt;should|should not&gt; &lt;be|contain|start with|end with|match regex|match xpath&gt; <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -329,7 +329,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-14">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-14" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-14" aria-expanded="true" aria-controls="collapseOne">
 					I capture the &lt;text|node|nodeset&gt; in <code>&lt;element|attribute|property&gt;</code> by xpath &quot;<code>&lt;expression&gt;</code>&quot; as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -350,7 +350,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-15">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-15" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-15" aria-expanded="true" aria-controls="collapseOne">
 					I capture the text in <code>&lt;element|attribute|property&gt;</code> by regex &quot;<code>&lt;expression&gt;</code>&quot; as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -371,7 +371,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-16">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-16" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-16" aria-expanded="true" aria-controls="collapseOne">
 					I capture the current URL </a>
 				</h4>
 			</div>
@@ -383,7 +383,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-17">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-17" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-17" aria-expanded="true" aria-controls="collapseOne">
 					I capture the current URL as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -402,7 +402,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-18">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-18" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-18" aria-expanded="true" aria-controls="collapseOne">
 					I capture <code>&lt;element|attribute|property&gt;</code> as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -422,7 +422,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-19">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-19" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-19" aria-expanded="true" aria-controls="collapseOne">
 					I capture <code>&lt;element|attribute|property&gt;</code>
 					</a>
 				</h4>
@@ -441,7 +441,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-20">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-20" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-20" aria-expanded="true" aria-controls="collapseOne">
 					I capture <code>&lt;dropdown&gt;</code> <code>&lt;text|value&gt;</code> as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -462,7 +462,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-21">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-21" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-21" aria-expanded="true" aria-controls="collapseOne">
 					I capture <code>&lt;dropdown&gt;</code> <code>&lt;text|value&gt;</code>
 					</a>
 				</h4>
@@ -482,7 +482,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-22">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-22" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-22" aria-expanded="true" aria-controls="collapseOne">
 					my <code>&lt;name&gt;</code> &lt;property|setting&gt; &lt;is|will be&gt; &quot;<code>&lt;value&gt;</code>&quot;
 					</a>
 				</h4>
@@ -502,7 +502,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-23">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-23" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-23" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined by &lt;javascript|system process|property|setting&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -522,7 +522,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-24">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-24" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-24" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined by the &lt;text|node|nodeset&gt; in <code>&lt;source&gt;</code> by xpath &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -543,7 +543,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-25">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-25" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-25" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined in <code>&lt;source&gt;</code> by regex &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
@@ -564,7 +564,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-26">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-26" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-26" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; &quot;<code>&lt;value&gt;</code>&quot;
 					</a>
 				</h4>
@@ -584,7 +584,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-27">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-27" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-27" aria-expanded="true" aria-controls="collapseOne">
 					I wait for <code>&lt;element&gt;</code> text for <code>&lt;duration&gt;</code> &lt;second|seconds&gt;
 					</a>
 				</h4>
@@ -604,7 +604,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-28">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-28" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-28" aria-expanded="true" aria-controls="collapseOne">
 					I wait for <code>&lt;element&gt;</code> text
 					</a>
 				</h4>
@@ -623,7 +623,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-29">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-29" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-29" aria-expanded="true" aria-controls="collapseOne">
 					I wait for <code>&lt;element&gt;</code> for <code>&lt;duration&gt;</code> &lt;second|seconds&gt;
 					</a>
 				</h4>
@@ -643,7 +643,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-30">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-30" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-30" aria-expanded="true" aria-controls="collapseOne">
 					I wait for <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -662,7 +662,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-31">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-31" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-31" aria-expanded="true" aria-controls="collapseOne">
 					I clear <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -681,7 +681,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-32">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-32" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-32" aria-expanded="true" aria-controls="collapseOne">
 					I press &lt;enter|tab&gt; in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -700,7 +700,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-33">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-33" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-33" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;enter|type&gt; &quot;<code>&lt;value&gt;</code>&quot; in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -720,7 +720,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-34">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-34" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-34" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;enter|type&gt; <code>&lt;attribute&gt;</code> in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -740,7 +740,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-35">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-35" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-35" aria-expanded="true" aria-controls="collapseOne">
 					I select the <code>&lt;position&gt;</code>&lt;st|nd|rd|th&gt; option in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -760,7 +760,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-36">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-36" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-36" aria-expanded="true" aria-controls="collapseOne">
 					I select &quot;<code>&lt;value&gt;</code>&quot; in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -780,7 +780,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-37">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-37" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-37" aria-expanded="true" aria-controls="collapseOne">
 					I select &quot;<code>&lt;value&gt;</code>&quot; in <code>&lt;element&gt;</code> by value
 					</a>
 				</h4>
@@ -800,7 +800,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-38">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-38" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-38" aria-expanded="true" aria-controls="collapseOne">
 					I select <code>&lt;attribute&gt;</code> in <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -820,7 +820,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-39">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-39" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-39" aria-expanded="true" aria-controls="collapseOne">
 					I select <code>&lt;attribute&gt;</code> in <code>&lt;element&gt;</code> by value
 					</a>
 				</h4>
@@ -840,7 +840,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-40">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-40" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-40" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;click|submit|check|uncheck&gt; <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -859,7 +859,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-41">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-41" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-41" aria-expanded="true" aria-controls="collapseOne">
 					I wait <code>&lt;duration&gt;</code> &lt;second|seconds&gt; when <code>&lt;element&gt;</code> is &lt;clicked|submitted|checked|unchecked|selected|typed|entered|tabbed|cleared&gt;
 					</a>
 				</h4>
@@ -879,7 +879,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-42">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-42" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-42" aria-expanded="true" aria-controls="collapseOne">
 					I wait until <code>&lt;condition&gt;</code> when <code>&lt;element&gt;</code> is &lt;clicked|submitted|checked|unchecked|selected|typed|entered|tabbed|cleared&gt;
 					</a>
 				</h4>
@@ -899,7 +899,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-43">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-43" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-43" aria-expanded="true" aria-controls="collapseOne">
 					I wait until &quot;<code>&lt;javascript&gt;</code>&quot;
 					</a>
 				</h4>
@@ -918,7 +918,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-44">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-44" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-44" aria-expanded="true" aria-controls="collapseOne">
 					I wait until <code>&lt;condition&gt;</code>
 					</a>
 				</h4>
@@ -937,7 +937,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-45">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-45" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-45" aria-expanded="true" aria-controls="collapseOne">
 					I wait <code>&lt;duration&gt;</code> &lt;second|seconds&gt;
 					</a>
 				</h4>
@@ -956,7 +956,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-46">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-46" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-46" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;highlight|locate&gt; <code>&lt;element&gt;</code>
 					</a>
 				</h4>
@@ -975,7 +975,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-47">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-47" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-47" aria-expanded="true" aria-controls="collapseOne">
 					I execute system process &quot;<code>&lt;process&gt;</code>&quot;
 					</a>
 				</h4>
@@ -994,7 +994,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-48">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-48" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-48" aria-expanded="true" aria-controls="collapseOne">
 					I execute a unix system process &quot;<code>&lt;process&gt;</code>&quot;
 					</a>
 				</h4>
@@ -1013,7 +1013,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-49">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-49" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-49" aria-expanded="true" aria-controls="collapseOne">
 					I refresh the current page </a>
 				</h4>
 			</div>
@@ -1025,7 +1025,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-50">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-50" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-50" aria-expanded="true" aria-controls="collapseOne">
 					I base64 decode <code>&lt;element|attribute&gt;</code> as <code>&lt;attribute&gt;</code>
 					</a>
 				</h4>
@@ -1045,7 +1045,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-51">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-51" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-51" aria-expanded="true" aria-controls="collapseOne">
 					I base64 decode <code>&lt;element|attribute&gt;</code>
 					</a>
 				</h4>
@@ -1064,7 +1064,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-52">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-52" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-52" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;step&gt;</code> until <code>&lt;condition&gt;</code>
 					</a>
 				</h4>
@@ -1084,7 +1084,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-53">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-53" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-53" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;step&gt;</code> while <code>&lt;condition&gt;</code>
 					</a>
 				</h4>
@@ -1105,11 +1105,11 @@ a:visited {
 	</div>
 
 	<em style="color:gray">Since v1.1.0</em>
-	<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+	<div class="panel-group" id="accordion1" role="tablist" aria-multiselectable="true">
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-1_1">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-1_1" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-1-1_1" aria-expanded="true" aria-controls="collapseOne">
 					<code>&lt;element&gt;</code> can be located by &lt;id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript&gt; &quot;<code>&lt;expression&gt;</code>&quot; in <code>&lt;container&gt;</code>
 					</a>
 				</h4>
@@ -1129,11 +1129,25 @@ a:visited {
 	</div>
 	
 	<em style="color:gray">Since v1.2.0</em>
-	<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+	<div class="panel-group" id="accordion2" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_0">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_0" aria-expanded="true" aria-controls="collapseOne">
+					I start a new browser</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_0" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_0">
+				<div class="panel-body">
+					Starts a new 'default' browser session (closes existing one if it is open first).
+				</div>
+			</div>
+		</div>
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-2_1">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
 					I close the current browser
 					</a>
 				</h4>
@@ -1147,14 +1161,14 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-2_2">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
 					I start a browser for <code>&lt;session&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_2">
 				<div class="panel-body">
-					Closes the current browser session (if one is open) and starts a new browser session with the given name.
+					Starts a new browser session with the given name (closes existing one if it is open first).
 					<ul>
 						<li><code>&lt;session&gt;</code> = the unique name to assign to the new browser session</li>
 					</ul>
@@ -1164,7 +1178,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-2_3">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
 					I close the browser for <code>&lt;session&gt;</code>
 					</a>
 				</h4>
@@ -1181,14 +1195,14 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-2_4">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_4" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_4" aria-expanded="true" aria-controls="collapseOne">
 					I switch to <code>&lt;session&gt;</code>
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_4">
 				<div class="panel-body">
-					Switches to a named browser session (starts one if required). All actions performed after this execute in the named session.
+					Switches to a named browser session (starts a new one if required). All actions performed after this execute in the named session.
 					<ul>
 						<li><code>&lt;session&gt;</code> = the name of the browser session to switch to</li>
 					</ul>
@@ -1198,7 +1212,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="dsl-1-2_5">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_5" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion2" href="#collapse-1-2_5" aria-expanded="true" aria-controls="collapseOne">
 					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
 					</a>
 				</h4>

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1127,6 +1127,28 @@ a:visited {
 			</div>
 		</div>
 	</div>
+	
+	<em style="color:gray">Since v1.2.0</em>
+	<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_1">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> in <code>&lt;container&gt;</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_1">
+				<div class="panel-body">
+					Performs the specified action on an element in a container
+					<ul>
+						<li><code>&lt;element&gt;</code> = the element to perform the action on</li>
+						<li><code>&lt;container&gt;</code> = the container element</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
 
 	<hr>
 	<div class="well well-sm">

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1134,16 +1134,44 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_1">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_1" aria-expanded="true" aria-controls="collapseOne">
-					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> in <code>&lt;container&gt;</code>
+					I start a new browser session
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_1">
 				<div class="panel-body">
-					Performs the specified action on an element in a container
+					Closes the current browser session (if one is open) and starts a new one.
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_2">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_2" aria-expanded="true" aria-controls="collapseOne">
+					I close the current browser session
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_2">
+				<div class="panel-body">
+					Closes the current browser session (if one is open).
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_3">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_3">
+				<div class="panel-body">
+					Performs the specified action on a context sensitive element
 					<ul>
 						<li><code>&lt;element&gt;</code> = the element to perform the action on</li>
-						<li><code>&lt;container&gt;</code> = the container element</li>
+						<li><code>&lt;context&gt;</code> = the context element to move into (in order to activate &lt;element&gt;)</li>
 					</ul>
 				</div>
 			</div>

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1162,11 +1162,62 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-2_3">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_3" aria-expanded="true" aria-controls="collapseOne">
-					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
+					I start a new browser session named &quot;<code>&lt;name&gt;</code>&quot;
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-2_3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_3">
+				<div class="panel-body">
+					Starts a new browser session with the given name. This can be used to create multiple uniquely named browser sessions.
+					<ul>
+						<li><code>&lt;name&gt;</code> = the unique name to assign to the new browser session</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_4">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_4" aria-expanded="true" aria-controls="collapseOne">
+					I close the browser session named &quot;<code>&lt;name&gt;</code>&quot;
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_4">
+				<div class="panel-body">
+					Closes a named browser session.
+					<ul>
+						<li><code>&lt;name&gt;</code> = the name of the browser session to close</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_5">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_5" aria-expanded="true" aria-controls="collapseOne">
+					I switch to the browser session named &quot;<code>&lt;name&gt;</code>&quot;
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_5" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_5">
+				<div class="panel-body">
+					Passes control to the named browser session. All actions performed after this step execute in the named browser.
+					<ul>
+						<li><code>&lt;name&gt;</code> = the name of the browser session to switch to</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-2_6">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse-1-2_6" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;click|check|uncheck&gt; <code>&lt;element&gt;</code> of <code>&lt;context&gt;</code>
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-2_6" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-2_6">
 				<div class="panel-body">
 					Performs the specified action on a context sensitive element
 					<ul>
@@ -1177,6 +1228,10 @@ a:visited {
 			</div>
 		</div>
 	</div>
+	
+	
+  - I close the browser session named "<name>"
+  - I switch to the browser session named "<name>"
 
 	<hr>
 	<div class="well well-sm">

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -190,9 +190,9 @@ I click <element>
 I check <element>
 I uncheck <element>
 I submit <element>
-I click <element> in <container>
-I check <element> in <container>
-I uncheck <element> in <container>
+I click <element> of <context>
+I check <element> of <context>
+I uncheck <element> of <context>
 I wait 1 second when <element> is clicked
 I wait 1 second when <element> is submitted
 I wait 1 second when <element> is checked
@@ -233,3 +233,5 @@ I base64 decode <reference> as <attribute>
 I base64 decode <reference>
 <step> until <condition>
 <step> while <condition>
+I start a new browser session
+I close the current browser session

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -234,6 +234,7 @@ I base64 decode <reference>
 <step> until <condition>
 <step> while <condition>
 I close the current browser
+I start a new browser
 I start a browser for <session>
 I close the browser for <session>
 I switch to <session>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -235,3 +235,6 @@ I base64 decode <reference>
 <step> while <condition>
 I start a new browser session
 I close the current browser session
+I start a new browser session named "<name>"
+I close the browser session named "<name>"
+I switch to the browser session named "<name>"

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -233,8 +233,8 @@ I base64 decode <reference> as <attribute>
 I base64 decode <reference>
 <step> until <condition>
 <step> while <condition>
-I start a new browser session
-I close the current browser session
-I start a new browser session named "<name>"
-I close the browser session named "<name>"
-I switch to the browser session named "<name>"
+I close the current browser
+I have a browser for <name>
+I start a browser for <name>
+I close the browser for <name>
+I switch to <name>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -234,7 +234,6 @@ I base64 decode <reference>
 <step> until <condition>
 <step> while <condition>
 I close the current browser
-I have a browser for <name>
-I start a browser for <name>
-I close the browser for <name>
-I switch to <name>
+I start a browser for <session>
+I close the browser for <session>
+I switch to <session>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -187,9 +187,12 @@ I select "<text>" in <element> by value
 I select <reference> in <element>
 I select <reference> in <element> by value
 I click <element>
-I submit <element>
 I check <element>
 I uncheck <element>
+I submit <element>
+I click <element> in <container>
+I check <element> in <container>
+I uncheck <element> in <container>
 I wait 1 second when <element> is clicked
 I wait 1 second when <element> is submitted
 I wait 1 second when <element> is checked

--- a/src/main/scala/gwen/web/DriverManager.scala
+++ b/src/main/scala/gwen/web/DriverManager.scala
@@ -46,13 +46,13 @@ trait DriverManager extends LazyLogging {
   /** Map of web driver instances (keyed by name). */
   private[web] val drivers: Map[String, WebDriver] = Map()
   
-  /** Current web driver instance. */
-  private[web] var currentDriver = "default"
+  /** Current web browser session. */
+  private[web] var currentBrowser = "default"
   
   /** Provides private access to the web driver */
-  private def webDriver: WebDriver = drivers.get(currentDriver) getOrElse {
+  private def webDriver: WebDriver = drivers.get(currentBrowser) getOrElse {
     loadWebDriver tap { driver =>
-      drivers += (currentDriver -> driver)
+      drivers += (currentBrowser -> driver)
     }
   }
   

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -443,6 +443,11 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.withWebDriver { _.navigate().refresh() }
       }
       
+      case r"I start a new browser" => env.execute {
+        env.quit("default")
+        env.switchTo("default")
+      }
+      
       case r"""I start a browser for (.+?)$$$session""" => env.execute {
         env.quit(session)
         env.switchTo(session)

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -417,11 +417,11 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         }
       }
         
-      case r"""I (click|check|uncheck)$action (.+?)$element in (.+?)$$$container""" => {
-        val containerBinding = env.getLocatorBinding(container)
+      case r"""I (click|check|uncheck)$action (.+?)$element of (.+?)$$$context""" => {
+        val contextBinding = env.getLocatorBinding(context)
         val elementBinding = env.getLocatorBinding(element)
         env.execute { 
-          env.performActionIn(action, elementBinding, containerBinding)
+          env.performActionIn(action, elementBinding, contextBinding)
         }
       }
       
@@ -441,6 +441,16 @@ trait WebEngine extends EvalEngine[WebEnvContext]
       
       case "I refresh the current page" => env.execute { 
         env.withWebDriver { _.navigate().refresh() }
+      }
+      
+      case "I start a new browser session" => env.execute {
+        env.quit()
+        env.withWebDriver { driver => // noop 
+        }
+      }
+      
+      case "I close the current browser session" => env.execute {
+        env.quit()
       }
       
       case _ => super.evaluate(step, env)

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -417,6 +417,14 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         }
       }
         
+      case r"""I (click|check|uncheck)$action (.+?)$element in (.+?)$$$container""" => {
+        val containerBinding = env.getLocatorBinding(container)
+        val elementBinding = env.getLocatorBinding(element)
+        env.execute { 
+          env.performActionIn(action, elementBinding, containerBinding)
+        }
+      }
+      
       case r"""I (click|submit|check|uncheck)$action (.+?)$$$element""" => {
         val elementBinding = env.getLocatorBinding(element)
         env.execute { 

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -445,12 +445,25 @@ trait WebEngine extends EvalEngine[WebEnvContext]
       
       case "I start a new browser session" => env.execute {
         env.quit()
-        env.withWebDriver { driver => // noop 
-        }
+        env.withWebDriver { driver => }
+      }
+      
+      case r"""I start a new browser session named (.+?)$$$name""" => env.execute {
+        env.quit(name)
+        env.currentDriver = name
+        env.withWebDriver { driver => }
       }
       
       case "I close the current browser session" => env.execute {
         env.quit()
+      }
+      
+      case r"""I close the browser session named (.+?)$$$name""" => env.execute {
+        env.quit(name)
+      }
+      
+      case r"""I switch to the browser session named (.+?)$$$name""" => env.execute {
+        env.currentDriver = name
       }
       
       case _ => super.evaluate(step, env)

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -443,27 +443,22 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.withWebDriver { _.navigate().refresh() }
       }
       
-      case "I start a new browser session" => env.execute {
-        env.quit()
+      case r"""I (?:have|start) a browser for (.+?)$$$name""" => env.execute {
+        env.quit(name)
+        env.currentBrowser = name
         env.withWebDriver { driver => }
       }
       
-      case r"""I start a new browser session named (.+?)$$$name""" => env.execute {
-        env.quit(name)
-        env.currentDriver = name
-        env.withWebDriver { driver => }
-      }
-      
-      case "I close the current browser session" => env.execute {
+      case "I close the current browser" => env.execute {
         env.quit()
       }
       
-      case r"""I close the browser session named (.+?)$$$name""" => env.execute {
+      case r"""I close the browser for (.+?)$name""" => env.execute {
         env.quit(name)
       }
       
-      case r"""I switch to the browser session named (.+?)$$$name""" => env.execute {
-        env.currentDriver = name
+      case r"""I switch to (.+?)$name""" => env.execute {
+        env.currentBrowser = name
       }
       
       case _ => super.evaluate(step, env)

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -443,22 +443,21 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.withWebDriver { _.navigate().refresh() }
       }
       
-      case r"""I (?:have|start) a browser for (.+?)$$$name""" => env.execute {
-        env.quit(name)
-        env.currentBrowser = name
-        env.withWebDriver { driver => }
+      case r"""I start a browser for (.+?)$$$session""" => env.execute {
+        env.quit(session)
+        env.switchTo(session)
       }
       
       case "I close the current browser" => env.execute {
         env.quit()
       }
       
-      case r"""I close the browser for (.+?)$name""" => env.execute {
-        env.quit(name)
+      case r"""I close the browser for (.+?)$session""" => env.execute {
+        env.quit(session)
       }
       
-      case r"""I switch to (.+?)$name""" => env.execute {
-        env.currentBrowser = name
+      case r"""I switch to (.+?)$session""" => env.execute {
+        env.switchTo(session)
       }
       
       case _ => super.evaluate(step, env)

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -538,18 +538,18 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
       action match {
         case "click" => webElement.click
         case "submit" => webElement.submit
-        case "check" if (!webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
-        case "uncheck" if (webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
+        case "check" => if (!webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
+        case "uncheck" => if (webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
       }
       bindAndWait(elementBinding.element, action, "true")
     }
   }
   
-  def performActionIn(action: String, elementBinding: LocatorBinding, containerBinding: LocatorBinding) {
-    withWebElement(action, containerBinding) { containerElement =>
+  def performActionIn(action: String, elementBinding: LocatorBinding, contextBinding: LocatorBinding) {
+    withWebElement(action, contextBinding) { contextElement =>
       withWebElement(action, elementBinding) { webElement =>
         withWebDriver { driver =>
-          var actions = new Actions(driver).moveToElement(containerElement).moveToElement(webElement)
+          var actions = new Actions(driver).moveToElement(contextElement).moveToElement(webElement)
           action match {
             case "click" => actions = actions.click
             case "check" => if (!webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -47,6 +47,7 @@ import gwen.errors._
 import scala.io.Source
 import scala.sys.process._
 import scala.collection.JavaConverters._
+import org.openqa.selenium.interactions.Actions
 
 /**
   * Defines the web environment context. This includes the configured selenium web
@@ -537,10 +538,27 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
       action match {
         case "click" => webElement.click
         case "submit" => webElement.submit
-        case "check" => if (!webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
-        case "uncheck" => if (webElement.isSelected()) webElement.sendKeys(Keys.SPACE)
+        case "check" if (!webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
+        case "uncheck" if (webElement.isSelected()) => webElement.sendKeys(Keys.SPACE)
       }
       bindAndWait(elementBinding.element, action, "true")
+    }
+  }
+  
+  def performActionIn(action: String, elementBinding: LocatorBinding, containerBinding: LocatorBinding) {
+    withWebElement(action, containerBinding) { containerElement =>
+      withWebElement(action, elementBinding) { webElement =>
+        withWebDriver { driver =>
+          var actions = new Actions(driver).moveToElement(containerElement).moveToElement(webElement)
+          action match {
+            case "click" => actions = actions.click
+            case "check" => if (!webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)
+            case "uncheck" => if (webElement.isSelected()) actions = actions.sendKeys(Keys.SPACE)
+          }
+          actions.build.perform()
+        }
+        bindAndWait(elementBinding.element, action, "true")
+      }
     }
   }
   

--- a/src/test/scala/gwen/web/WebDslTest.scala
+++ b/src/test/scala/gwen/web/WebDslTest.scala
@@ -24,6 +24,8 @@ class WebDslTest extends FlatSpec {
     env.scopes.set("<condition>/javascript", "condition")
     env.scopes.set("<container>/locator", "id");
     env.scopes.set("<container>/locator/id", "id")
+    env.scopes.set("<context>/locator", "id")
+    env.scopes.set("<context>/locator/id", "id")
         
     val interpreter = new WebInterpreter
     withSetting("<name>", "name") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.1.1"
+git.baseVersion := "1.2.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
This feature adds support for driving multiple browser sessions in a feature.  Each session is identified by a given name.

For example, the following starts two browser sessions named Gwen and Gwen-web, switches between them, and performs operations in each.

```gherkin
Given I start a browser for Gwen
  And I start a browser for Gwen-web

# Switch to the Gwen browser and navigate to a URL
Given I switch to Gwen
 When I navigate to "https://github.com/gwen-interpreter/gwen"
 Then the page title should start with "gwen-interpreter/gwen:"

# Switch to the Gwen-web session and navigate to a URL
Given I switch to Gwen-web
 When I navigate to "https://github.com/gwen-interpreter/gwen-web"
 Then the page title should start with "gwen-interpreter/gwen-web:"
```

Any number of sessions can be created in a feature. You can switch between sessions at any time.  When the feature exits, then all browser sessions also exit.

If you want to explicitly close a session, you can do it like this:

```gherkin
# close the Gwen session
Given I close the browser for Gwen
```

All bound data in the environment context is shared between sessions.
