### PR TITLE
Accepting/dismissing popup boxes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.4.0
+=====
+Mar 19, 1026, 12:56 PM GMT+11 (AEDT)
+- Add support for accepting and dismissing browser popup boxes. New DSL includes:
+  - I <accept|dismiss> the popup box
+
 1.3.1
 =====
 Mar 6, 2016, 10:21 PM GMT+11 (AEDT)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 =====
 Mar 19, 1026, 12:56 PM GMT+11 (AEDT)
 - Add support for accepting and dismissing browser popup boxes. New DSL includes:
-  - I <accept|dismiss> the popup box
+  - I <accept|dismiss> the <alert|confirmation> popup
 
 1.3.1
 =====

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ specifications instead of code.
 
 [![Build Status](https://travis-ci.org/gwen-interpreter/gwen-web.svg?branch=master)](https://travis-ci.org/gwen-interpreter/gwen-web)
 
-- Current release: [1.3.1](https://github.com/gwen-interpreter/gwen-web/releases/tag/v1.3.1)
+- Current release: [1.4.0](https://github.com/gwen-interpreter/gwen-web/releases/tag/v1.4.0)
 - [Change log](CHANGELOG)
 
 Core Requirements

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1245,6 +1245,24 @@ a:visited {
 		</div>
 	</div>
 	
+	<em style="color:gray">Since v1.4.0</em>
+	<div class="panel-group" id="accordion4" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-4_1">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4_1" aria-expanded="true" aria-controls="collapseOne">
+					I &lt;accept|dismiss&gt; the popup box 
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-4_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-4_1">
+				<div class="panel-body">
+					Accepts or dismisses a popup box (browser alert or confirmation). Accept clicks OK and dismiss clicks Cancel. Cancel is only available in confirmation alerts.
+				</div>
+			</div>
+		</div>
+	</div>
+	
 	<a href="https://github.com/gwen-interpreter/gwen-web/wiki">&lt; Gwen-Web Wiki</a>
 
 	<hr>

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1251,13 +1251,13 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-1-4_1">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4_1" aria-expanded="true" aria-controls="collapseOne">
-					I &lt;accept|dismiss&gt; the popup box 
+					I &lt;accept|dismiss&gt; the &lt;alert|confirmation&gt; popup 
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-1-4_1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-4_1">
 				<div class="panel-body">
-					Accepts or dismisses a popup box (browser alert or confirmation). Accept clicks OK and dismiss clicks Cancel. Cancel is only available in confirmation alerts.
+					Accepts or dismisses an alert or confirmation popup box. Accept clicks OK and dismiss clicks Cancel. Cancel is only available in confirmation popups.
 				</div>
 			</div>
 		</div>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -239,5 +239,6 @@ I start a new browser
 I start a browser for <session>
 I close the browser for <session>
 I switch to <session>
-I accept the popup box
-I dismiss the popup box
+I accept the alert popup
+I accept the confirmation popup
+I dismiss the confirmation popup

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -239,3 +239,5 @@ I start a new browser
 I start a browser for <session>
 I close the browser for <session>
 I switch to <session>
+I accept the popup box
+I dismiss the popup box

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -478,7 +478,7 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.switchTo(session)
       }
       
-      case r"I (accept|dismiss)$action the popup box" => env.execute {
+      case r"I (accept|dismiss)$action the (?:alert|confirmation) popup" => env.execute {
         env.withWebDriver { driver =>
           if (action == "accept") {
             driver.switchTo().alert().accept()

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -478,6 +478,16 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.switchTo(session)
       }
       
+      case r"I (accept|dismiss)$action the popup box" => env.execute {
+        env.withWebDriver { driver =>
+          if (action == "accept") {
+            driver.switchTo().alert().accept()
+          } else {
+            driver.switchTo().alert().dismiss()
+          }
+        }
+      }
+        
       case _ => super.evaluate(step, env)
       
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.3.1"
+git.baseVersion := "1.4.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
This feature adds the following DSL for accepting or dismissing alert and confirmation popup boxes. Alert boxes can be accepted only. Confirmation boxes can be accepted or dismissed.

`I <accept|dismiss> the <alert|confirmation> popup`

- `I accept the alert popup` will click the OK button in an alert popup
- `I accept the confirmation popup` will click the OK button in a confirmation popup
- `I dismiss the confirmation popup` will click the Cancel button in a confirmation popup