### PR TITLE
Switching between parent and child windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
 1.4.0
 =====
-Mar 19, 1026, 12:56 PM GMT+11 (AEDT)
+Mar 23, 2016, 12:02 PM GMT+11 (AEDT)
 - Add support for accepting and dismissing browser popup boxes. New DSL includes:
   - I <accept|dismiss> the <alert|confirmation> popup
+- Add ability to switch between parent and child windows. New DSL includes:
+  - I switch to the child window
+  - I close the child window
+  - I switch to the parent window
 
 1.3.1
 =====

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1261,6 +1261,48 @@ a:visited {
 				</div>
 			</div>
 		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-4_2">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4_2" aria-expanded="true" aria-controls="collapseOne">
+					I switch to the child window
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-4_2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-4_2">
+				<div class="panel-body">
+					Passes control over to the most recently opened child window (without closing the parent window).
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-4_3">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4_3" aria-expanded="true" aria-controls="collapseOne">
+					I close the child window
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-4_3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-4_3">
+				<div class="panel-body">
+					Closes the currently active child window and passes control back to the parent window.
+				</div>
+			</div>
+		</div>
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-1-4_4">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4_4" aria-expanded="true" aria-controls="collapseOne">
+					I switch to the parent window
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-4_4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-1-4_4">
+				<div class="panel-body">
+					Passes control back to the parent window (without closing the currently active child window).
+				</div>
+			</div>
+		</div>
 	</div>
 	
 	<a href="https://github.com/gwen-interpreter/gwen-web/wiki">&lt; Gwen-Web Wiki</a>

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -242,3 +242,6 @@ I switch to <session>
 I accept the alert popup
 I accept the confirmation popup
 I dismiss the confirmation popup
+I switch to the child window
+I close the child window
+I switch to the parent window

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -457,13 +457,13 @@ trait WebEngine extends EvalEngine[WebEnvContext]
       }
       
       case r"I start a new browser" => env.execute {
-        env.quit("default")
-        env.switchTo("default")
+        env.quit("primary")
+        env.switchToSession("primary")
       }
       
       case r"""I start a browser for (.+?)$$$session""" => env.execute {
         env.quit(session)
-        env.switchTo(session)
+        env.switchToSession(session)
       }
       
       case r"I close the(?: current)? browser" => env.execute {
@@ -474,8 +474,20 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.quit(session)
       }
       
+      case r"""I switch to the child window""" => env.execute {
+        env.withWebDriver(env.switchToChild)
+      }
+      
+      case r"""I close the child window""" => env.execute {
+        env.closeChild()
+      }
+      
+      case r"""I switch to the parent window""" => env.execute {
+        env.switchToParent(false)
+      }
+      
       case r"""I switch to (.+?)$session""" => env.execute {
-        env.switchTo(session)
+        env.switchToSession(session)
       }
       
       case r"I (accept|dismiss)$action the (?:alert|confirmation) popup" => env.execute {

--- a/src/main/scala/gwen/web/errors.scala
+++ b/src/main/scala/gwen/web/errors.scala
@@ -24,9 +24,13 @@ package gwen {
     package object errors {
 
       def unsupportedWebDriverError(driverName: String) = throw new UnsupportedWebDriverException(driverName)
+      def noSuchWindowError(msg: String) = throw new NoSuchWindowException(msg)
 
       /** Thrown when an unsupported web driver is detected. */
-      class UnsupportedWebDriverException(driverName: String) extends Exception(s"Unsupported web driver: ${driverName}")
+      class UnsupportedWebDriverException(driverName: String) extends RuntimeException(s"Unsupported web driver: ${driverName}")
+      
+      /** Thrown when an attempt is made to switch to a window that does not exist. */
+      class NoSuchWindowException(msg: String) extends RuntimeException(msg)
 
     }
   }


### PR DESCRIPTION
This features add support for switching to child windows, closing child windows, and switching back to parent windows. It introduces the following new DSLs:

- `I switch to the child window`
  - Passes control over to the most recently opened child window (without closing the parent window)
- `I close the child window`
  - Closes the currently active child window and passes control back to the parent window
- `I switch to the parent window`
  - Passes control back to the parent window (without closing the currently active child window) 