### PR TITLE
Avoid contiguous screenshot duplicates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 1.4.0
 =====
-Mar 29, 2016, 15:26 PM GMT+11 (AEDT)
+Mar 30 2016, 2:24 AM GMT+11 (AEDT)
 - Add support for accepting and dismissing browser popup boxes. New DSL includes:
   - I <accept|dismiss> the <alert|confirmation> popup
 - Add ability to switch between parent and child windows. New DSL includes:
@@ -12,6 +12,8 @@ Mar 29, 2016, 15:26 PM GMT+11 (AEDT)
     of the last captured screenshot.
   - This feature is now on by default. It can be turned off by setting: 
       gwen.web.capture.screenshots.duplicates=true
+- Updated Gwen from v1.1.1 to v[1.1.2](https://github.com/gwen-interpreter/gwen/releases/tag/v1.1.2)
+  - To pick up sequence counter number fix for all attachment filenames
 
 1.3.1
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,17 @@
 1.4.0
 =====
-Mar 23, 2016, 12:02 PM GMT+11 (AEDT)
+Mar 29, 2016, 15:26 PM GMT+11 (AEDT)
 - Add support for accepting and dismissing browser popup boxes. New DSL includes:
   - I <accept|dismiss> the <alert|confirmation> popup
 - Add ability to switch between parent and child windows. New DSL includes:
   - I switch to the child window
   - I close the child window
   - I switch to the parent window
+- Avoid contiguous duplicate screenshots 
+  - Solution was to discard the current screenshot if its size in bytes matches that 
+    of the last captured screenshot.
+  - This feature is now on by default. It can be turned off by setting: 
+      gwen.web.capture.screenshots.duplicates=true
 
 1.3.1
 =====

--- a/docs/conf/gwen-web-settings.html
+++ b/docs/conf/gwen-web-settings.html
@@ -40,11 +40,11 @@ a:visited {
 	<br>
 	<br>
 	<em style="color:gray">Since v1.0.0</em>
-	<div class="panel-group" id="accordion0" role="tablist" aria-multiselectable="true">
+	<div class="panel-group" id="accordion1" role="tablist" aria-multiselectable="true">
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-0">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-0" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-0" aria-expanded="true" aria-controls="collapseOne">
 					gwen.feature.failfast
 					</a>
 				</h4>
@@ -62,7 +62,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-1">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-1" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-1" aria-expanded="true" aria-controls="collapseOne">
 					gwen.feature.failfast.exit
 					</a>
 				</h4>
@@ -80,7 +80,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-2">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-2" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-2" aria-expanded="true" aria-controls="collapseOne">
 					gwen.report.slideshow.framespersecond
 					</a>
 				</h4>
@@ -98,7 +98,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-3">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-3" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-3" aria-expanded="true" aria-controls="collapseOne">
 					gwen.report.overwrite
 					</a>
 				</h4>
@@ -116,7 +116,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-4">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-4" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-4" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.browser
 					</a>
 				</h4>
@@ -134,7 +134,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-5">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-5" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-5" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.useragent
 					</a>
 				</h4>
@@ -151,7 +151,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-6">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-6" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-6" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.authorize.plugins
 					</a>
 				</h4>
@@ -169,7 +169,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-7">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-7" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-7" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.wait.seconds
 					</a>
 				</h4>
@@ -187,7 +187,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-8">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-8" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-8" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.maximize
 					</a>
 				</h4>
@@ -205,7 +205,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-9">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-9" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-9" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.throttle.msecs
 					</a>
 				</h4>
@@ -223,7 +223,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-10">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-10" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-10" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.highlight.style
 					</a>
 				</h4>
@@ -241,7 +241,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-11">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-11" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-11" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.capture.screenshots
 					</a>
 				</h4>
@@ -259,7 +259,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-12">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-12" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-12" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.capture.screenshots.highlighting
 					</a>
 				</h4>
@@ -277,7 +277,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-13">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-13" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-13" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.remote.url
 					</a>
 				</h4>
@@ -294,7 +294,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-14">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-14" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-14" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.accept.untrusted.certs
 					</a>
 				</h4>
@@ -312,7 +312,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-15">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-15" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-15" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.suppress.images
 					</a>
 				</h4>
@@ -330,7 +330,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-16">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-16" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-16" aria-expanded="true" aria-controls="collapseOne">
 					gwen.web.chrome.extensions
 					</a>
 				</h4>
@@ -347,7 +347,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-17">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-17" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-17" aria-expanded="true" aria-controls="collapseOne">
 					log4j.configuration
 					</a>
 				</h4>
@@ -365,11 +365,11 @@ a:visited {
 	</div>
 	
 	<em style="color:gray">Since v1.3.0</em>
-	<div class="panel-group" id="accordion1" role="tablist" aria-multiselectable="true">
+	<div class="panel-group" id="accordion3" role="tablist" aria-multiselectable="true">
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-1-3-0">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-1-3-0" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion3" href="#collapse-1-3-0" aria-expanded="true" aria-controls="collapseOne">
 					gwen.rampup.interval.seconds
 					</a>
 				</h4>
@@ -386,7 +386,7 @@ a:visited {
 		<div class="panel panel-default">
 			<div class="panel-heading" role="tab" id="settings-1-3-1">
 				<h4 class="panel-title">
-					<a role="button" data-toggle="collapse" data-parent="#accordion1" href="#collapse-1-3-1" aria-expanded="true" aria-controls="collapseOne">
+					<a role="button" data-toggle="collapse" data-parent="#accordion3" href="#collapse-1-3-1" aria-expanded="true" aria-controls="collapseOne">
 					gwen.report.suppress.meta
 					</a>
 				</h4>
@@ -401,6 +401,29 @@ a:visited {
 				</div>
 			</div>
 		</div>
+	</div>
+	
+	<em style="color:gray">Since v1.4.0</em>
+	<div class="panel-group" id="accordion4" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="settings-1-4-0">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion4" href="#collapse-1-4-0" aria-expanded="true" aria-controls="collapseOne">
+					gwen.web.capture.screenshots.duplicates
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-1-4-0" class="panel-collapse collapse" role="tabpanel" aria-labelledby="settings-1-4-0">
+				<div class="panel-body">
+					Controls whether or not contiguous duplicate screenshots should be captured or discarded
+					<ul>
+					    <li><em>default:</em> <code>false</code>
+						<li><em>supported:</em> <code>true</code> to capture duplicates, <code>false</code> to discard duplicates
+					</ul>
+				</div>
+			</div>
+		</div>
+
 	</div>
 
 	<a href="https://github.com/gwen-interpreter/gwen-web/wiki/Gwen-Web-User-Guide">&lt; Gwen-Web Wiki</a>

--- a/src/main/scala/gwen/web/DriverManager.scala
+++ b/src/main/scala/gwen/web/DriverManager.scala
@@ -158,16 +158,16 @@ trait DriverManager extends LazyLogging {
     }
   }
    
-  /** Captures and returns the current screenshot as an attachment (name-file pair). */
-  private[web] def captureScreenshot(unconditional: Boolean): Option[(String, File)] = {
+  /** Captures and the current screenshot and adds it to the attachments list. */
+  private[web] def captureScreenshot(unconditional: Boolean) {
     Thread.sleep(WebSettings.`gwen.web.throttle.msecs` / 2)
     val screenshot = webDriver.asInstanceOf[TakesScreenshot].getScreenshotAs(OutputType.FILE)
-    val screenChanged = unconditional || WebSettings.`gwen.web.capture.screenshots.duplicates` || env.attachments.filter(_._1 == "Screenshot").lastOption.fold(true) { case (_, imgFile) => imgFile.length != screenshot.length}
-    if (screenChanged) {
-      Some(env.addAttachment("Screenshot", screenshot.getName.substring(screenshot.getName.lastIndexOf('.') + 1), null) tap { 
+    val keep = unconditional || WebSettings.`gwen.web.capture.screenshots.duplicates` || env.attachments.filter(_._1 == "Screenshot").lastOption.fold(true) { case (_, imgFile) => imgFile.length != screenshot.length}
+    if (keep) {
+      env.addAttachment("Screenshot", screenshot.getName.substring(screenshot.getName.lastIndexOf('.') + 1), null) tap { 
         case (name, file) => FileUtils.copyFile(screenshot, file)
-      })
-    } else None
+      }
+    }
   }
   
   /** Loads the selenium webdriver. */

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -82,7 +82,7 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
     withWebDriver { webDriver => 
       webDriver.asInstanceOf[JavascriptExecutor].executeScript(javascript, params.map(_.asInstanceOf[AnyRef]) : _*) tap { result =>
         if (takeScreenShot && WebSettings.`gwen.web.capture.screenshots`) {
-          captureScreenshot(false) foreach (addAttachment)
+          captureScreenshot(false)
         }
         logger.debug(s"Evaluated javascript: $javascript, result='$result'")
         if (result.isInstanceOf[Boolean] && result.asInstanceOf[Boolean]) {

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -82,7 +82,7 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
     withWebDriver { webDriver => 
       webDriver.asInstanceOf[JavascriptExecutor].executeScript(javascript, params.map(_.asInstanceOf[AnyRef]) : _*) tap { result =>
         if (takeScreenShot && WebSettings.`gwen.web.capture.screenshots`) {
-          addAttachment(captureScreenshot())
+          captureScreenshot(false) foreach (addAttachment)
         }
         logger.debug(s"Evaluated javascript: $javascript, result='$result'")
         if (result.isInstanceOf[Boolean] && result.asInstanceOf[Boolean]) {
@@ -182,7 +182,7 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
     */
   override def addErrorAttachments(failure: Failed): Unit = {
     super.addErrorAttachments(failure)
-    execute(captureScreenshot())
+    execute(captureScreenshot(true))
   }
     
   /**
@@ -228,7 +228,7 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
       }
       f(webElement) tap { result =>
         if (WebSettings.`gwen.web.capture.screenshots`) {
-          captureScreenshot()
+          captureScreenshot(false)
         }
       }
     } catch {

--- a/src/main/scala/gwen/web/WebSettings.scala
+++ b/src/main/scala/gwen/web/WebSettings.scala
@@ -112,4 +112,12 @@ object WebSettings {
    * or location paths). Each extension provided is loaded into the Chrome web driver.
    */
   def `gwen.web.chrome.extensions`: List[File] = Settings.getOpt("gwen.web.chrome.extensions").map(_.split(",").toList).getOrElse(Nil).map(new File(_))
+  
+  /**
+    * Provides access to the `gwen.web.capture.screenshots.duplicates` setting used to control whether 
+    * or not the web driver should capture or discard contiguously duplicate screenshots 
+    * (default value is `false` ~ to discard). If set to `false`, then a screenshot will be discarded 
+    * if its size in bytes matches that of the last captured screenshot.
+    */
+  def `gwen.web.capture.screenshots.duplicates`: Boolean = Settings.getOpt("gwen.web.capture.screenshots.duplicates").getOrElse("false").toBoolean
 }


### PR DESCRIPTION
When screenshots are enabled (`gwen.web.capture.screenshots=true`), there are times when the same screen images are captured more than once. This feature remedies this by discarding screenshots that are identical to the previous one that was captured. Screenshots are considered identical if they are the same size (in bytes). Given that the captured screenshot format is PNG, comparing the sizes has been found to be good enough for practical purposes and much more efficient than performing actual image comparisons. If this solution turns out to be inadequate, we can add more checks or change the implementation. But I have observed positive results with this approach so far.

With this change, duplicate screenshots will be discarded by default. Users can turn this mechanism off by setting the following property to `true`: 
- `gwen.web.capture.screenshots.duplicates`
  - `false` to discard duplicate screenshots (default behavior)
  - `true` to keep all screenshots