### PR TITLE
Feature/gwen2 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
+add_ons:
+  - firefox: "50.1.0"
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
   - mkdir geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
-add_ons:
-  - firefox: "47.0"
+addons:
+  firefox: "49.0.2"
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.13.0-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: scala
 scala:
-   - 2.11.8
+   - 2.12.1
 jdk:
   - oraclejdk8
-  - oraclejdk7
 before_script:
   # pull down gwen source dependency
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 add_ons:
-  - firefox: "50.1.0"
+  - firefox: "47.0"
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
   - mkdir geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,8 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
+before_install:
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.13.0/geckodriver-v0.13.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.13.0-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2.0.0
+=====
+
+Jan 20, 2017
+- Update to Java 8 (Java 7 no longer supported)
+- Update from Scala 2.11.8 to 2.12.1
+- Update Gwen from v1.4.3 to v[2.0.0](https://github.com/gwen-interpreter/gwen/releases/tag/v2.0.0)
+  
 1.11.10
 =======
 Nov 25, 2016, 6:30 PM GMT+10 (AEDT)

--- a/LICENSE-THIRDPARTY
+++ b/LICENSE-THIRDPARTY
@@ -2,8 +2,8 @@ LICENSE-THIRDPARTY
 ==================
 
 Dependency                                               | Version     | License
--------------------------------------------------------- | ----------- | -----------------------------------------------------------------------------  
-cglib                           cglib-nodep              | 2.1_3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+-------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------
+cglib                           cglib-nodep              | 3.2.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 com.fasterxml.jackson.core      jackson-annotations      | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 com.fasterxml.jackson.core      jackson-core             | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
 com.fasterxml.jackson.core      jackson-databind         | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -19,7 +19,7 @@ com.typesafe.play               play-functional_2.12     | 2.6.0-M1    | [Apache
 com.typesafe.play               play-json_2.12           | 2.6.0-M1    | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 com.typesafe.scala-logging      scala-logging_2.12       | 3.5.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 commons-codec                   commons-codec            | 1.10        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-commons-io                      commons-io               | 2.4         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+commons-io                      commons-io               | 2.5         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 commons-logging                 commons-logging          | 1.2         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
 io.cucumber                     gherkin                  | 4.0.0       | [MIT License](http://www.opensource.org/licenses/mit-license)
 io.cucumber                     gherkin-jvm-deps         | 1.0.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -32,18 +32,16 @@ net.java.dev.jna                jna-platform             | 4.1.0       | [Apache
 net.minidev                     accessors-smart          | 1.1         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 net.minidev                     json-smart               | 2.2.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.apache.commons              commons-exec             | 1.3         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.apache.httpcomponents       httpclient               | 4.5.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.apache.httpcomponents       httpcore                 | 4.4.3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.httpcomponents       httpclient               | 4.5.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.httpcomponents       httpcore                 | 4.4.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.httpcomponents       httpmime                 | 4.5.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.ow2.asm                     asm                      | 5.0.3       | [BSD License](http://asm.objectweb.org/license.html)
 org.scala-lang                  scala-library            | 2.12.1      | [BSD 3-Clause](https://www.scala-lang.org/license.html)
 org.scala-lang                  scala-reflect            | 2.12.1      | [BSD 3-Clause](https://www.scala-lang.org/license.html) 
 org.seleniumhq.selenium         selenium-api             | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
 org.seleniumhq.selenium         selenium-chrome-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium         selenium-edge-driver     | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.seleniumhq.selenium         selenium-firefox-driver  | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.seleniumhq.selenium         selenium-ie-driver       | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium         selenium-java            | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium         selenium-leg-rc          | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.seleniumhq.selenium         selenium-remote-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.seleniumhq.selenium         selenium-safari-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 org.seleniumhq.selenium         selenium-support         | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)   

--- a/LICENSE-THIRDPARTY
+++ b/LICENSE-THIRDPARTY
@@ -1,63 +1,57 @@
 LICENSE-THIRDPARTY
 ==================
 
-Dependency                                           | Version     | License
----------------------------------------------------- | ----------- | -----------------------------------------------------------------------------  
-joda-time                   joda-time                | 2.3         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.joda                    joda-convert             | 1.6         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-com.typesafe.scala-logging  scala-logging-api_2.11   | 2.1.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-com.typesafe.scala-logging  scala-logging-slf4j_2.11 | 2.1.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-cglib                       cglib-nodep              | 2.1_3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.fasterxml.jackson.core  jackson-annotations      | 2.3.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.fasterxml.jackson.core  jackson-core             | 2.3.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-com.fasterxml.jackson.core  jackson-databind         | 2.3.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.github.tototoshi        scala-csv_2.11           | 1.2.2       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.google.guava            guava                    | 19.0        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.typesafe                config                   | 1.2.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-commons-codec               commons-codec            | 1.10        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-io.cucumber                 gherkin-jvm-deps         | 1.0.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-commons-io                  commons-io               | 2.4         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-commons-logging             commons-logging          | 1.2         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-io.netty                    netty                    | 3.5.7.Final | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-net.java.dev.jna            jna                      | 4.1.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-net.java.dev.jna            jna-platform             | 4.1.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-org.apache.commons          commons-exec             | 1.3         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.apache.httpcomponents   httpclient               | 4.5.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.apache.httpcomponents   httpcore                 | 4.4.3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.fusesource.jansi        jansi                    | 1.11        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-api             | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-org.seleniumhq.selenium     selenium-chrome-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-edge-driver     | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-firefox-driver  | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-ie-driver       | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-java            | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-leg-rc          | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-remote-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-safari-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-org.seleniumhq.selenium     selenium-support         | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.typesafe.play           play-datacommons_2.11    | 2.3.9       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.typesafe.play           play-functional_2.11     | 2.3.9       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.typesafe.play           play-iteratees_2.11      | 2.3.9       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.typesafe.play           play-json_2.11           | 2.3.9       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-com.google.code.findbugs    jsr305                   | 2.0.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-com.google.code.gson        gson                     | 2.3.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-log4j                       log4j                    | 1.2.17      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-com.jayway.jsonpath         json-path                | 2.2.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-net.minidev                 accessors-smart          | 1.1         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-net.minidev                 json-smart               | 2.2.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
-org.scala-stm               scala-stm_2.11           | 0.7         | [BSD](https://github.com/nbronson/scala-stm/blob/master/LICENSE.txt) 
-org.scala-lang              scala-library            | 2.11.8      | [BSD 3-Clause](http://www.scala-lang.org/license.html)
-org.scala-lang              scala-reflect            | 2.11.1      | [BSD 3-Clause](http://www.scala-lang.org/license.html)
-org.webbitserver            webbit                   | 0.4.14      | [BSD License](https://github.com/webbit/webbit/blob/master/LICENSE)
-org.ow2.asm                 asm                      | 5.0.3       | [BSD License](http://asm.objectweb.org/license.html)
-jline                       jline                    | 2.13        | [The BSD License](https://github.com/jline/jline2/blob/master/LICENSE.txt)
-com.github.scopt            scopt_2.11               | 3.3.0       | [MIT License](http://www.opensource.org/licenses/mit-license)
-io.cucumber                 gherkin                  | 4.0.0       | [MIT License](http://www.opensource.org/licenses/mit-license)
-org.slf4j                   slf4j-api                | 1.7.16      | [MIT License](http://www.slf4j.org/license.html)
-org.slf4j                   slf4j-log4j12            | 1.7.7       | [MIT License](http://www.slf4j.org/license.html)
-Twitter, Inc                Bootstrap                | 3.3.6       | [MIT License](https://github.com/twbs/bootstrap/blob/master/LICENSE)
-The jQuery Foundation       JQuery                   | 2.1.4       | [MIT License](https://jquery.org/license)
-Petr Vostřel                Reel                     | 1.3         | [MIT License](https://github.com/pisi/Reel/blob/master/LICENSE.txt)
+Dependency                                               | Version     | License
+-------------------------------------------------------- | ----------- | -----------------------------------------------------------------------------  
+cglib                           cglib-nodep              | 2.1_3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.fasterxml.jackson.core      jackson-annotations      | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.fasterxml.jackson.core      jackson-core             | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
+com.fasterxml.jackson.core      jackson-databind         | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.fasterxml.jackson.datatype  jackson-datatype-jdk8    | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.fasterxml.jackson.datatype  jackson-datatype-jsr310  | 2.8.5       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.github.scopt                scopt_2.12               | 3.5.0       | [MIT License](http://www.opensource.org/licenses/mit-license)
+com.github.tototoshi            scala-csv_2.12           | 1.3.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.google.code.findbugs        jsr305                   | 2.0.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.google.code.gson            gson                     | 2.3.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.google.guava                guava                    | 19.0        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.jayway.jsonpath             json-path                | 2.2.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.typesafe.play               play-functional_2.12     | 2.6.0-M1    | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.typesafe.play               play-json_2.12           | 2.6.0-M1    | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+com.typesafe.scala-logging      scala-logging_2.12       | 3.5.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+commons-codec                   commons-codec            | 1.10        | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+commons-io                      commons-io               | 2.4         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+commons-logging                 commons-logging          | 1.2         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
+io.cucumber                     gherkin                  | 4.0.0       | [MIT License](http://www.opensource.org/licenses/mit-license)
+io.cucumber                     gherkin-jvm-deps         | 1.0.4       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+io.netty                        netty                    | 3.5.7.Final | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+jline                           jline                    | 2.14.2      | [The BSD License](https://github.com/jline/jline2/blob/master/LICENSE.txt)
+joda-time                       joda-time                | 2.9.7       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+log4j                           log4j                    | 1.2.17      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+net.java.dev.jna                jna                      | 4.1.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+net.java.dev.jna                jna-platform             | 4.1.0       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
+net.minidev                     accessors-smart          | 1.1         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+net.minidev                     json-smart               | 2.2.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.commons              commons-exec             | 1.3         | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.httpcomponents       httpclient               | 4.5.1       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.apache.httpcomponents       httpcore                 | 4.4.3       | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.ow2.asm                     asm                      | 5.0.3       | [BSD License](http://asm.objectweb.org/license.html)
+org.scala-lang                  scala-library            | 2.12.1      | [BSD 3-Clause](https://www.scala-lang.org/license.html)
+org.scala-lang                  scala-reflect            | 2.12.1      | [BSD 3-Clause](https://www.scala-lang.org/license.html) 
+org.seleniumhq.selenium         selenium-api             | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) 
+org.seleniumhq.selenium         selenium-chrome-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-edge-driver     | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-firefox-driver  | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-ie-driver       | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-java            | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-leg-rc          | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-remote-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-safari-driver   | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+org.seleniumhq.selenium         selenium-support         | 2.53.1      | [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)   
+org.slf4j                       slf4j-api                | 1.7.22      | [MIT License](http://www.slf4j.org/license.html)
+org.slf4j                       slf4j-log4j12            | 1.7.22      | [MIT License](http://www.slf4j.org/license.html)
+Twitter, Inc                    Bootstrap                | 3.3.6       | [MIT License](https://github.com/twbs/bootstrap/blob/master/LICENSE)
+The jQuery Foundation           JQuery                   | 2.1.4       | [MIT License](https://jquery.org/license)
+Petr Vostřel                    Reel                     | 1.3         | [MIT License](https://github.com/pisi/Reel/blob/master/LICENSE.txt)
  
 LICENSES
 --------
@@ -299,12 +293,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # [BSD 3-Clause](http://www.scala-lang.org/license.html)
 
 ```
-Copyright (c) 2002-2016 EPFL
-Copyright (c) 2011-2016 Typesafe, Inc.
+Copyright (c) 2002-2017 EPFL
+Copyright (c) 2011-2017 Lightbend, Inc.
 
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are  
+Redistribution and use in source and binary forms, with or without modification, are 
 permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice, this list of 

--- a/README.md
+++ b/README.md
@@ -34,15 +34,19 @@ Key Features
 * [Interchangeable Selenium](https://github.com/gwen-interpreter/gwen-web/wiki/Runtime-Settings#changing-the-selenium-version) implementation
 * [Locator Chaining](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Chaining)
 
-Core Requirements
------------------
+Runtime Requirements
+--------------------
 
-- Java JRE 7+
-- A web browser (Chrome, Firefox, Safari, or IE)
-- A native web driver (required for Chrome and IE only)
+- Java SE 8 Runtime Environment
+- A web browser
+- Native web driver
+  - [Safari](https://webkit.org/blog/6900/webdriver-support-in-safari-10/)
+  - [Chrome](https://sites.google.com/a/chromium.org/chromedriver/)
+  - [Edge](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
+  - [Firefox](https://github.com/mozilla/geckodriver/releases)
 
 Quick Links to Wiki Information
------------
+-------------------------------
 - [Installation](https://github.com/gwen-interpreter/gwen-web/wiki/Installation) 
 - [Getting Started](https://github.com/gwen-interpreter/gwen-web/wiki/Getting-Started)
 - [Gwen-Web DSL](http://htmlpreview.github.io/?https://github.com/gwen-interpreter/gwen-web/blob/master/docs/dsl/gwen-web-dsl.html)

--- a/build.sbt
+++ b/build.sbt
@@ -38,15 +38,23 @@ resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
 resolvers += "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-chrome-driver" % "3.0.1"
+
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-firefox-driver" % "3.0.1"
+
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-ie-driver" % "3.0.1"
+
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-safari-driver" % "3.0.1"
+
+libraryDependencies += "org.seleniumhq.selenium" % "selenium-support" % "3.0.1" excludeAll(
+  ExclusionRule(organization = "junit")
+)
+
+libraryDependencies += "commons-io" % "commons-io" % "2.5"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 libraryDependencies += "org.mockito" % "mockito-all" % "1.10.19" % "test"
-
-libraryDependencies += "com.google.code.findbugs" % "jsr305" % "2.0.1" % "compile" 
-
-libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "2.53.1" excludeAll(
-  ExclusionRule(organization = "org.seleniumhq.selenium", name = "selenium-htmlunit-driver")
-)
 
 mappings in (Compile, packageBin) ++= Seq(
   file("LICENSE") -> "LICENSE",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ organizationHomepage := Some(url("http://gweninterpreter.org"))
 
 startYear := Some(2014)
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
 crossPaths := false
 
@@ -24,13 +24,11 @@ scalacOptions += "-language:postfixOps"
 
 scalacOptions += "-deprecation"
 
-scalacOptions += "-target:jvm-1.7"
+scalacOptions += "-target:jvm-1.8"
 
 licenses += "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
 
 homepage := Some(url("https://github.com/gwen-interpreter/gwen-web"))
-
-EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource
 
 javaSource in Compile := baseDirectory.value / "src/main/scala"
 
@@ -40,7 +38,7 @@ resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
 resolvers += "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 libraryDependencies += "org.mockito" % "mockito-all" % "1.10.19" % "test"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.9
+sbt.version = 0.13.13

--- a/src/main/scala/gwen/web/DriverManager.scala
+++ b/src/main/scala/gwen/web/DriverManager.scala
@@ -32,7 +32,7 @@ import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.HttpCommandExecutor
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.safari.SafariDriver
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import gwen.Predefs.Kestrel
 import gwen.Predefs.RegexContext
 import org.apache.commons.io.FileUtils
@@ -43,6 +43,7 @@ import scala.collection.mutable.Map
 import gwen.GwenSettings
 import scala.collection.mutable.Stack
 import gwen.errors.AmbiguousCaseException
+import collection.JavaConverters._
 
 /** Provides access to the web driver used to drive the browser. */
 trait DriverManager extends LazyLogging { 
@@ -89,8 +90,7 @@ trait DriverManager extends LazyLogging {
     * @param driver the current web driver 
     */
   private[web] def switchToChild(driver: WebDriver) {
-    import collection.JavaConversions._
-    val children = driver.getWindowHandles.filter(window => windows.forall(_ != window)).toList match {
+    val children = driver.getWindowHandles.asScala.filter(window => windows.forall(_ != window)).toList match {
       case Nil if windows.size > 1 => windows.init
       case cs => cs
     }

--- a/src/main/scala/gwen/web/WebElementLocator.scala
+++ b/src/main/scala/gwen/web/WebElementLocator.scala
@@ -21,7 +21,7 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebDriverException
 import org.openqa.selenium.WebElement
 import gwen.Predefs.Kestrel
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import scala.util.Try
 import scala.util.Success
 import scala.util.Failure

--- a/src/test/scala/gwen/web/DriverManagerTest.scala
+++ b/src/test/scala/gwen/web/DriverManagerTest.scala
@@ -29,7 +29,7 @@ import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import gwen.Settings
 import gwen.UserOverrides
 import gwen.eval.EnvContext

--- a/src/test/scala/gwen/web/WebElementLocatorTest.scala
+++ b/src/test/scala/gwen/web/WebElementLocatorTest.scala
@@ -29,7 +29,7 @@ import org.openqa.selenium.WebElement
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import gwen.eval.ScopedDataStack
 import gwen.eval.GwenOptions
 import org.openqa.selenium.WebDriver.TargetLocator

--- a/src/test/scala/gwen/web/WebEngineTest.scala
+++ b/src/test/scala/gwen/web/WebEngineTest.scala
@@ -23,7 +23,7 @@ import org.mockito.Matchers.any
 import org.openqa.selenium.WebDriver
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import gwen.eval.ScopedDataStack
 import gwen.eval.GwenOptions
 import gwen.dsl.Step

--- a/src/test/scala/gwen/web/WebEnvContextTest.scala
+++ b/src/test/scala/gwen/web/WebEnvContextTest.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.verify
 import org.openqa.selenium.WebDriver
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import gwen.eval.ScopedDataStack
 import gwen.eval.GwenOptions
 

--- a/src/test/scala/gwen/web/WebInterpreterSequentialTest.scala
+++ b/src/test/scala/gwen/web/WebInterpreterSequentialTest.scala
@@ -19,7 +19,7 @@ package gwen.web
 class WebInterpreterSequentialTest extends WebInterpreterTest {
 
   "Sequential mode" should "evaluate all features in sequence" in {
-    evaluate(List("features/floodio", "features/blogs", "features/etsy", "features/meta-imports"), false, false, "target/reports/sequential", None)
+    evaluate(List("features/floodio", "features/blogs/automationByMeta", "features/etsy", "features/meta-imports"), false, false, "target/reports/sequential", None)
   }
   
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.11.0"
+git.baseVersion := "2.0.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
Gwen 2.0.0 Upgrade
===============

This is an upgrade to Java 8, Scala 2.12.1, and Selenium WebDriver 3.0.1  Java 7 is no longer supported. There is one configuration impact to FireFox, but nothing else has changed for Gwen.

All binary dependencies have also been upgraded to the latest versions. With this upgrade, Gwen is now using all the latest binaries.

Firefox Impact
--------------
As of version 3 of WebDriver, all browser vendors (including Mozilla Firefox) for developing and providing the native drivers. See: https://seleniumhq.wordpress.com/2016/10/13/selenium-3-0-out-now/

This means that you now need to install a native driver for Firefox.  The Firefox drivers are available here:
https://github.com/mozilla/geckodriver/releases

To use Firefox with Gwen 2.x you need to download the native driver and set the following property in your gwen.properties file to point to it (or put the driver on your system path).

`webdriver.gecko.driver=/your-downloaded-driver-location/geckodriver`

