### PR TITLE
Add support for SQL data bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
   # pull down gwen source dependency
   - cd ..
   - git clone https://github.com/gwen-interpreter/gwen.git
+  - cd gwen
+  - git checkout feature/sql-bindings
+  - cd ..
   - cd gwen-web
   # use virtual frame buffers to run browser tests
   - "export DISPLAY=:99.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2.1.0
+=====
+Jan 27, 2017
+  - Added SQL support for binding attributes to fields in databases
+  - Introduced GWEN_CLASSPATH environment variable for adding external JARs to Gwen classpath
+  - new DSL: <attribute> <is|will be> defined by sql "<selectStmt>" in the <dbName> database
+  - Update Gwen from v2.0.0 to v[2.1.0](https://github.com/gwen-interpreter/gwen/releases/tag/v2.1.0)
+
 2.0.1
 =====
 Jan 27, 2017

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -479,14 +479,13 @@ a:visited {
 			<div class="panel-heading" role="tab" id="dsl-23">
 				<h4 class="panel-title">
 					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-23" aria-expanded="true" aria-controls="collapseOne">
-					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined by &lt;javascript|system process|property|setting|file&gt; &quot;<code>&lt;expression&gt;</code>&quot;
+					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined by &lt;javascript|system process|property|setting&gt; &quot;<code>&lt;expression&gt;</code>&quot;
 					</a>
 				</h4>
 			</div>
 			<div id="collapse-23" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-23">
 				<div class="panel-body">
-					Binds an expression to a named attribute. The evaluation occurs when the attribute is referenced.
-					(Note: Support for "file" type binding is only available in v1.11.0 and above)
+					Binds an expression to a named attribute. The evaluation will occur when the attribute is referenced at runtime.
 					<ul>
 						<li><code>&lt;attribute&gt;</code> = the name of the attribute to bind the value to</li>
 						<li><code>&lt;expression&gt;</code> = the expression that will yield the value to bind</li>
@@ -1532,6 +1531,57 @@ a:visited {
 					<ul>
 						<li><code>&lt;attribute&gt;</code> = the name of the attribute to bind the value to</li>
 						<li><code>&lt;filepath&gt;</code> = the path to the file</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+	
+	<em style="color:gray">Since v2.1.0</em>
+	<div class="panel-group" id="accordion11" role="tablist" aria-multiselectable="true">	
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="dsl-2-1_1">
+				<h4 class="panel-title">
+					<a role="button" data-toggle="collapse" data-parent="#accordion0" href="#collapse-2-1" aria-expanded="true" aria-controls="collapseOne">
+					<code>&lt;attribute&gt;</code> &lt;is|will be&gt; defined by sql &quot;<code>&lt;selectStmt&gt;</code>&quot; in the <code>&lt;dbName&gt;</code> database
+					</a>
+				</h4>
+			</div>
+			<div id="collapse-2-1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-2-1_1">
+				<div class="panel-body">
+					Binds the result of an SQL select query to a named attribute. The query must return one result and one field only.
+					The query will be executed and the result will be bound to the attribute when it is referenced at evaluation time.
+					<ul>
+						<li><code>&lt;attribute&gt;</code> = the name of the attribute to bind the SQL result to</li>
+						<li><code>&lt;selectStmt&gt;</code> = the SQL select query statement (must return one result with one field)</li>
+						<li><code>&lt;dbName&gt;</code> = the name of database to execute the query on. This name is used to configure the database as follows:
+						  <ul>
+						    <li>The <code>GWEN_CLASSPATH</code> <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#environment-variables">environment variable</a> must be set to include a path to the JDBC driver JAR 
+						    <li>A gwen.db.<code>&lt;dbName&gt;</code>.driver <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings">setting</a> must be set to the name of the JDBC driver implementation class
+						    <li>A gwen.db.<code>&lt;dbName&gt;</code>.url <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings">setting</a> must be set to the JDBC URL of the database
+						  </ul>
+						</li>
+					</ul>
+					Example using mysql:
+					<ul>
+					  <li>Set GWEN_CLASSPATH variable in the environment to include the JDBC driver JAR
+					      <ul>
+						    <li>Unix: export GWEN_CLASSPATH=/path-to-driver/mysql-connector-java-5.1.40-bin.jar</li>
+						    <li>Windows: set GWEN_CLASSPATH=c:/path-to-driver/mysql-connector-java-5.1.40-bin.jar</li>
+						  </ul>
+					  </li>
+					  <li>Configure the database in your <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings">Gwen settings</a>. In this example, <code>&lt;dbName&gt;</code>=feedback
+					      <ul>
+					        <li>gwen.db.<b>feedback</b>.driver = com.mysql.jdbc.Driver</li>
+					        <li>gwen.db.<b>feedback</b>.url = jdbc:mysql://localhost/feedback?user=myUser&amp;password=myPassword&amp;serverTimezone=UTC&amp;useSSL=false</li>
+					      </ul>
+					  </li>
+					  <li>Bind a database field and use it in your feature
+					    <ul>
+					      <li>Given <b>the email</b> is defined by sql "<b>select email from comments</b>" in the <b>feedback</b> database</li>
+					      <li>Then <b>the email</b> should be "the.email@gmail.com"
+					    </ul>
+					  </li>
 					</ul>
 				</div>
 			</div>

--- a/docs/dsl/gwen-web-dsl.html
+++ b/docs/dsl/gwen-web-dsl.html
@@ -1549,11 +1549,14 @@ a:visited {
 			</div>
 			<div id="collapse-2-1" class="panel-collapse collapse" role="tabpanel" aria-labelledby="dsl-2-1_1">
 				<div class="panel-body">
-					Binds the result of an SQL select query to a named attribute. The query must return one result and one field only.
+					Binds the result of an SQL select query to a named attribute. The query must return a result in one field only.
+					If more than one record is returned, then the result in the first one will be returned and the others discarded.
+					For best results, you should narrow the query using a where clause to ensure that only one record is returned.
+					If no records are returned, then an error stating that no records were found will be reported. 
 					The query will be executed and the result will be bound to the attribute when it is referenced at evaluation time.
 					<ul>
 						<li><code>&lt;attribute&gt;</code> = the name of the attribute to bind the SQL result to</li>
-						<li><code>&lt;selectStmt&gt;</code> = the SQL select query statement (must return one result with one field)</li>
+						<li><code>&lt;selectStmt&gt;</code> = the SQL select query statement</li>
 						<li><code>&lt;dbName&gt;</code> = the name of database to execute the query on. This name is used to configure the database as follows:
 						  <ul>
 						    <li>The <code>GWEN_CLASSPATH</code> <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#environment-variables">environment variable</a> must be set to include a path to the JDBC driver JAR 
@@ -1567,7 +1570,7 @@ a:visited {
 					  <li>Set GWEN_CLASSPATH variable in the environment to include the JDBC driver JAR
 					      <ul>
 						    <li>Unix: export GWEN_CLASSPATH=/path-to-driver/mysql-connector-java-5.1.40-bin.jar</li>
-						    <li>Windows: set GWEN_CLASSPATH=c:/path-to-driver/mysql-connector-java-5.1.40-bin.jar</li>
+						    <li>Windows: set GWEN_CLASSPATH c:/path-to-driver/mysql-connector-java-5.1.40-bin.jar</li>
 						  </ul>
 					  </li>
 					  <li>Configure the database in your <a href="https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings">Gwen settings</a>. In this example, <code>&lt;dbName&gt;</code>=feedback

--- a/package.sbt
+++ b/package.sbt
@@ -44,8 +44,8 @@ mappings in Universal <++= (com.typesafe.sbt.packager.Keys.makeBatScript in Univ
 val BashClasspathPattern = "declare -r app_classpath=\"(.*)\"\n".r
 
 bashScriptDefines := bashScriptDefines.value.map {
-  case BashClasspathPattern(classpath) => "declare -r app_classpath=\"$SELENIUM_HOME/*:$SELENIUM_HOME/libs/*:" + classpath + "\"\n"
+  case BashClasspathPattern(classpath) => "declare -r app_classpath=\"$GWEN_CLASSPATH:$SELENIUM_HOME/*:$SELENIUM_HOME/libs/*:" + classpath + "\"\n"
   case _@entry => entry
 }
 
-batScriptExtraDefines += """set "APP_CLASSPATH=%SELENIUM_HOME%\*;%SELENIUM_HOME%\libs\*;%APP_CLASSPATH%""""
+batScriptExtraDefines += """set "APP_CLASSPATH=%GWEN_CLASSPATH%;%SELENIUM_HOME%\*;%SELENIUM_HOME%\libs\*;%APP_CLASSPATH%""""

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -300,3 +300,5 @@ I capture the current screenshot
 <element> can be submitted by javascript "<javascript>"
 <element> can be checked by javascript "<javascript>"
 <element> can be unchecked by javascript "<javascript>"
+<reference> is defined by sql "<selectStmt>" in the <dbName> database
+<reference> will be defined by sql "<selectStmt>" in the <dbName> database

--- a/src/main/scala/gwen/web/WebEngine.scala
+++ b/src/main/scala/gwen/web/WebEngine.scala
@@ -324,6 +324,10 @@ trait WebEngine extends EvalEngine[WebEnvContext]
         env.scopes.set(s"$attribute/json path/source", source)
         env.scopes.set(s"$attribute/json path/expression", expression)
       
+      case r"""(.+?)$attribute (?:is|will be) defined by sql "(.+?)"$selectStmt in the (.+?)$dbName database""" =>
+        env.scopes.set(s"$attribute/sql/selectStmt", selectStmt)
+        env.scopes.set(s"$attribute/sql/dbName", dbName)
+
       case r"""I clear (.+?)$$$element""" => {
         val elementBinding = env.getLocatorBinding(element)
         env.execute {

--- a/src/test/scala/gwen/web/WebEnvContextTest.scala
+++ b/src/test/scala/gwen/web/WebEnvContextTest.scala
@@ -145,6 +145,14 @@ class WebEnvContextTest extends FlatSpec with Matchers with MockitoSugar {
     env.getAttribute("xml") should be ("$[file:path-to/file.xml]")
   }
   
+  "Attribute with sql binding" should "resolve" in {
+    val mockDriverManager = mock[DriverManager]
+    val env = newEnv(mockDriverManager, true)
+    env.scopes.set("username/sql/selectStmt", "select username from users")
+    env.scopes.set("username/sql/dbName", "subscribers")
+    env.getAttribute("username") should be ("$[sql:select username from users]")
+  }
+  
   def newEnv(browser: DriverManager, dry:Boolean = false) = {
     
    new WebEnvContext(GwenOptions(dryRun=dry), new ScopedDataStack()) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.0.1"
+git.baseVersion := "2.1.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
## SQL bindings

This feature allows users to execute SQL queries on databases and bind their results to named attributes in Gwen. This is facilitated through the following new DSL:

`<attribute> <is|will be> defined by sql "<selectStmt>" in the <dbName> database`

Where:

- `<attribute>` = the name of the attribute to bind the SQL result to
- `<selectStmt>` = the SQL select query statement (must return one result with one field)
- `<dbName>` = the name of database to execute the query on. This name is used to configure the database as follows:
  - A `gwen.db.<dbName>.driver` setting must be set to the name of the JDBC driver implementation class
  - A `gwen.db.<dbName>.url` setting must be set to the JDBC URL of the database
  - The `GWEN_CLASSPATH` environment variable must be set to include a path to the JDBC driver JAR

If more than one record is returned by a query, then the result in the first one will be returned and the others discarded. For best results, you should narrow the query using a where clause to ensure that only one record is returned. If no records are returned, then an error stating that no records were found will be reported. The query will be executed and the result will be bound to the attribute when it is referenced at evaluation time.

## An example using a MySQL database

### Sample usage:

The following example executes a query on a comments table in a feedback database and assigns the result to `the email` attribute and then checks the value. This example returns the value of the first record. A more realistic example would narrow the records down to one result by including a where clause in the select statement.

```
# define the binding using a select query (in meta)
Given the email is defined by sql "select email from comments" in the feedback database

# check the value returned by the query (in the feature)
 Then the email should be "the.email@gmail.com"
```
### Sample configuration:

To enable the above to work with Gwen, you will need to perform the following:

- Download the JDBC driver JAR for your database.
- Set the `GWEN_CLASSPATH` variable in the environment to include the path to the JDBC driver JAR
  - Unix: `export GWEN_CLASSPATH=/path-to-driver/mysql-connector-java-5.1.40-bin.jar`
  - Windows: `set GWEN_CLASSPATH=c:/path-to-driver/mysql-connector-java-5.1.40-bin.jar`
- Configure the database in your Gwen settings (gwen.properties file). In this example, `<dbName>=feedback`
  - `gwen.db.feedback.driver = com.mysql.jdbc.Driver`
  - `gwen.db.feedback.url = jdbc:mysql://localhost/feedback?user=myUser&password=myPassword&serverTimezone=UTC&useSSL=false`
