### PR TITLE
Locator level timeouts (implicit waits)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,9 +5,35 @@ Apr 29, 2018
 - Add DSL to support inserting new lines into text fields (to address issue #56 raised by @anshu781126 )
   - `I insert a new line in <element>`
 - Add following setting for tuning locator timeouts (implicit web driver waits) independently of Gwen repeats and
-  assertion timeouts.
+  assertions:
   - `gwen.web.locator.wait.seconds`
     - will default to `gwen.web.wait.seconds` if not overridden or to 10 seconds if that value is not configured either
+- Add support for overriding configured timeouts (implicit waits) at the locator level.
+  The following DSLs were introduced:
+  - `<element> can be located by <locator> "<expression>" with no wait`
+  - `<element> can be located by <locator> "<expression>" with <timeoutPeriod> second timeout`
+  - `<element> can be located by <locator> "<expression>" in <container> with no wait`
+  - `<element> can be located by <locator> "<expression>" in <container> with <timeoutPeriod> second timeout`
+  - `<step> for each <element> located by <locator> "<expression>" with no wait`
+  - `<step> for each <element> located by <locator> "<expression>" with <timeoutPeriod> second timeout`
+  - `<step> for each <element> located by <locator> "<expression>" in <container> with no wait`
+  - `<step> for each <element> located by <locator> "<expression>" in <container> with <timeoutPeriod> second timeout`
+  - <element> can be located with no wait by
+      | locator 1  | expression 1  |
+      | locator 2  | expression 2  |
+      | locator .. | expression .. |
+      | locator N  | expression N  |
+    - Where
+      - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
+      - column 2 = the lookup expression literal
+  - <element> can be located with <timeoutPeriod> second timeout by
+      | locator 1  | expression 1  |
+      | locator 2  | expression 2  |
+      | locator .. | expression .. |
+      | locator N  | expression N  |
+    - Where
+      - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
+      - column 2 = the lookup expression literal
 
 2.18.0
 ======

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,19 +18,23 @@ Apr 29, 2018
   - `<step> for each <element> located by <locator> "<expression>" with <timeoutPeriod> second timeout`
   - `<step> for each <element> located by <locator> "<expression>" in <container> with no wait`
   - `<step> for each <element> located by <locator> "<expression>" in <container> with <timeoutPeriod> second timeout`
-  - <element> can be located with no wait by
+  - ```
+    <element> can be located with no wait by
       | locator 1  | expression 1  |
       | locator 2  | expression 2  |
       | locator .. | expression .. |
       | locator N  | expression N  |
+    ```
     - Where
       - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
       - column 2 = the lookup expression literal
-  - <element> can be located with <timeoutPeriod> second timeout by
+  - ```
+     <element> can be located with <timeoutPeriod> second timeout by
       | locator 1  | expression 1  |
       | locator 2  | expression 2  |
       | locator .. | expression .. |
       | locator N  | expression N  |
+    ```
     - Where
       - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
       - column 2 = the lookup expression literal

--- a/src/main/resources/gwen-web.dsl
+++ b/src/main/resources/gwen-web.dsl
@@ -15,6 +15,24 @@ I scroll to the bottom of <element>
 <element> can be located by link text "<value>"
 <element> can be located by partial link text "<value>"
 <element> can be located by javascript "<expression>"
+<element> can be located by id "<value>" with no wait
+<element> can be located by name "<value>" with no wait
+<element> can be located by tag name "<value>" with no wait
+<element> can be located by css selector "<value>" with no wait
+<element> can be located by xpath "<value>" with no wait
+<element> can be located by class name "<value>" with no wait
+<element> can be located by link text "<value>" with no wait
+<element> can be located by partial link text "<value>" with no wait
+<element> can be located by javascript "<expression>" with no wait
+<element> can be located by id "<value>" with <timeoutPeriod> second timeout
+<element> can be located by name "<value>" with <timeoutPeriod> second timeout
+<element> can be located by tag name "<value>" with <timeoutPeriod> second timeout
+<element> can be located by css selector "<value>" with <timeoutPeriod> second timeout
+<element> can be located by xpath "<value>" with <timeoutPeriod> second timeout
+<element> can be located by class name "<value>" with <timeoutPeriod> second timeout
+<element> can be located by link text "<value>" with <timeoutPeriod> second timeout
+<element> can be located by partial link text "<value>" with <timeoutPeriod> second timeout
+<element> can be located by javascript "<expression>" with <timeoutPeriod> second timeout
 <element> can be located by id "<value>" in <container>
 <element> can be located by name "<value>" in <container>
 <element> can be located by tag name "<value>" in <container>
@@ -24,6 +42,24 @@ I scroll to the bottom of <element>
 <element> can be located by link text "<value>" in <container>
 <element> can be located by partial link text "<value>" in <container>
 <element> can be located by javascript "<expression>" in <container>
+<element> can be located by id "<value>" in <container> with no wait
+<element> can be located by name "<value>" in <container> with no wait
+<element> can be located by tag name "<value>" in <container> with no wait
+<element> can be located by css selector "<value>" in <container> with no wait
+<element> can be located by xpath "<value>" in <container> with no wait
+<element> can be located by class name "<value>" in <container> with no wait
+<element> can be located by link text "<value>" in <container> with no wait
+<element> can be located by partial link text "<value>" in <container> with no wait
+<element> can be located by javascript "<expression>" in <container> with no wait
+<element> can be located by id "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by name "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by tag name "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by css selector "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by xpath "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by class name "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by link text "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by partial link text "<value>" in <container> with <timeoutPeriod> second timeout
+<element> can be located by javascript "<expression>" in <container> with <timeoutPeriod> second timeout
 the page title should be "<value>"
 the page title should contain "<value>"
 the page title should start with "<value>"
@@ -423,6 +459,24 @@ I maximise the window
 <step> for each <element> located by link text "<expression>"
 <step> for each <element> located by partial link text "<expression>"
 <step> for each <element> located by javascript "<expression>"
+<step> for each <element> located by id "<expression>" with no wait
+<step> for each <element> located by name "<expression>" with no wait
+<step> for each <element> located by tag name "<expression>" with no wait
+<step> for each <element> located by css selector "<expression>" with no wait
+<step> for each <element> located by xpath "<expression>" with no wait
+<step> for each <element> located by class name "<expression>" with no wait
+<step> for each <element> located by link text "<expression>" with no wait
+<step> for each <element> located by partial link text "<expression>" with no wait
+<step> for each <element> located by javascript "<expression>" with no wait
+<step> for each <element> located by id "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by name "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by tag name "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by css selector "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by xpath "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by class name "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by link text "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by partial link text "<expression>" with <timeoutPeriod> second timeout
+<step> for each <element> located by javascript "<expression>" with <timeoutPeriod> second timeout
 <step> for each <element> located by id "<expression>" in <container>
 <step> for each <element> located by name "<expression>" in <container>
 <step> for each <element> located by tag name "<expression>" in <container>
@@ -432,6 +486,24 @@ I maximise the window
 <step> for each <element> located by link text "<expression>" in <container>
 <step> for each <element> located by partial link text "<expression>" in <container>
 <step> for each <element> located by javascript "<expression>" in <container>
+<step> for each <element> located by id "<expression>" in <container> with no wait
+<step> for each <element> located by name "<expression>" in <container> with no wait
+<step> for each <element> located by tag name "<expression>" in <container> with no wait
+<step> for each <element> located by css selector "<expression>" in <container> with no wait
+<step> for each <element> located by xpath "<expression>" in <container> with no wait
+<step> for each <element> located by class name "<expression>" in <container> with no wait
+<step> for each <element> located by link text "<expression>" in <container> with no wait
+<step> for each <element> located by partial link text "<expression>" in <container> with no wait
+<step> for each <element> located by javascript "<expression>" in <container> with no wait
+<step> for each <element> located by id "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by name "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by tag name "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by css selector "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by xpath "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by class name "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by link text "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by partial link text "<expression>" in <container> with <timeoutPeriod> second timeout
+<step> for each <element> located by javascript "<expression>" in <container> with <timeoutPeriod> second timeout
 <step> for each <element> in <elements>
 <step> for each data record
 <attribute> should be absent

--- a/src/test/scala/gwen/web/WebElementLocatorTest.scala
+++ b/src/test/scala/gwen/web/WebElementLocatorTest.scala
@@ -16,19 +16,20 @@
 
 package gwen.web
 
+import java.util.concurrent.TimeUnit
+
 import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.never
 import org.mockito.Mockito.doReturn
-import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.when
+import org.mockito.Mockito.verifyZeroInteractions
 import org.openqa.selenium.By
-import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.firefox.FirefoxDriver
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 import gwen.eval.ScopedDataStack
 import gwen.eval.GwenOptions
@@ -37,17 +38,31 @@ import org.openqa.selenium.WebDriver.{Options, TargetLocator, Timeouts}
 import org.openqa.selenium.NoSuchElementException
 import org.mockito.Matchers.{anyVararg, same}
 
-class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
+import scala.concurrent.duration.Duration
 
-  val mockWebElement: WebElement = mock[WebElement]
-  val mockWebElements: List[WebElement] = List(mock[WebElement], mock[WebElement])
-  val mockContainerElement: WebElement = mock[WebElement]
-  val mockIFrameElement: WebElement = mock[WebElement]
-  val mockFrameElement: WebElement = mock[WebElement]
-  val mockTargetLocator: TargetLocator = mock[TargetLocator]
-  val mockWebDriverOptions: Options = mock[WebDriver.Options]
-  val mockWebDriverTimeouts: Timeouts = mock[WebDriver.Timeouts]
-  val mockDriverManager: DriverManager = mock[DriverManager]
+class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  private var mockWebElement: WebElement = _
+  private var mockWebElements: List[WebElement] = _
+  private var mockContainerElement: WebElement = _
+  private var mockIFrameElement: WebElement = _
+  private var mockFrameElement: WebElement = _
+  private var mockTargetLocator: TargetLocator = _
+  private var mockWebDriverOptions: Options = _
+  private var mockWebDriverTimeouts: Timeouts = _
+  private var mockDriverManager: DriverManager = _
+
+  override def beforeEach(): Unit = {
+    mockWebElement = mock[WebElement]
+    mockWebElements = List(mock[WebElement], mock[WebElement])
+    mockContainerElement = mock[WebElement]
+    mockIFrameElement = mock[WebElement]
+    mockFrameElement = mock[WebElement]
+    mockTargetLocator = mock[TargetLocator]
+    mockWebDriverOptions = mock[WebDriver.Options]
+    mockWebDriverTimeouts = mock[WebDriver.Timeouts]
+    mockDriverManager = mock[DriverManager]
+  }
 
   "Attempt to locate non existent element" should "throw no such element error" in {
 
@@ -65,35 +80,87 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
   }
   
   "Attempt to locate existing element by id" should "return the element" in {
-    shouldFindWebElement("id", "uname", By.id("uname"))
+    shouldFindWebElement("id", "uname", By.id("uname"), None)
+  }
+
+  "Attempt to locate existing element by id with no wait" should "return the element" in {
+    shouldFindWebElement("id", "uname", By.id("uname"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by id with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("id", "uname", By.id("uname"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by name" should "return the element" in {
-    shouldFindWebElement("name", "uname", By.name("uname"))
+    shouldFindWebElement("name", "uname", By.name("uname"), None)
+  }
+
+  "Attempt to locate existing element by name with no wait" should "return the element" in {
+    shouldFindWebElement("name", "uname", By.name("uname"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by name with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("name", "uname", By.name("uname"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by tag name" should "return the element" in {
-    shouldFindWebElement("tag name", "input", By.tagName("input"))
+    shouldFindWebElement("tag name", "input", By.tagName("input"), None)
+  }
+
+  "Attempt to locate existing element by tag name with no wait" should "return the element" in {
+    shouldFindWebElement("tag name", "input", By.tagName("input"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by tag name with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("tag name", "input", By.tagName("input"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by css selector" should "return the element" in {
-    shouldFindWebElement("css selector", ":focus", By.cssSelector(":focus"))
+    shouldFindWebElement("css selector", ":focus", By.cssSelector(":focus"), None)
+  }
+
+  "Attempt to locate existing element by css selector with no wait" should "return the element" in {
+    shouldFindWebElement("css selector", ":focus", By.cssSelector(":focus"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by css selector with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("css selector", ":focus", By.cssSelector(":focus"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by xpath" should "return the element" in {
-    shouldFindWebElement("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"))
+    shouldFindWebElement("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), None)
+  }
+
+  "Attempt to locate existing element by xpath with no wait" should "return the element" in {
+    shouldFindWebElement("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by xpath with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by class name" should "return the element" in {
-    shouldFindWebElement("class name", ".userinput", By.className(".userinput"))
+    shouldFindWebElement("class name", ".userinput", By.className(".userinput"), None)
+  }
+
+  "Attempt to locate existing element by class name with no wait" should "return the element" in {
+    shouldFindWebElement("class name", ".userinput", By.className(".userinput"), Some(Duration.Zero))
   }
   
-  "Attempt to locate existing element by link text" should "return the element" in {
-    shouldFindWebElement("link text", "User name", By.linkText("User name"))
+  "Attempt to locate existing element by link text with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("link text", "User name", By.linkText("User name"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by partial link text" should "return the element" in {
-    shouldFindWebElement("partial link text", "User", By.partialLinkText("User"))
+    shouldFindWebElement("partial link text", "User", By.partialLinkText("User"), None)
+  }
+
+  "Attempt to locate existing element by partial link text with no wait" should "return the element" in {
+    shouldFindWebElement("partial link text", "User", By.partialLinkText("User"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing element by partial link text with 2 second timeout" should "return the element" in {
+    shouldFindWebElement("partial link text", "User", By.partialLinkText("User"), Some(Duration.create(2, TimeUnit.SECONDS)))
   }
   
   "Attempt to locate existing element by javascript" should "return the element" in {
@@ -111,6 +178,47 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
     locator.locate(LocatorBinding("username", locatorType, lookup, None)) should be (mockWebElement)
     
     verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verifyZeroInteractions(mockWebDriverTimeouts)
+
+  }
+
+  "Attempt to locate existing element by javascript with no wait" should "return the element" in {
+
+    val locatorType = "javascript"
+    val lookup = "document.getElementById('username')"
+    val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
+    val locator = newLocator(None, mockWebDriver)
+
+    when(mockWebDriver.manage()).thenReturn(mockWebDriverOptions)
+    when(mockWebDriverOptions.timeouts()).thenReturn(mockWebDriverTimeouts)
+    doReturn(mockWebElement).when(mockWebDriver).executeScript(s"return $lookup")
+    when(mockWebElement.isDisplayed).thenReturn(true)
+
+    locator.locate(LocatorBinding("username", locatorType, lookup, None, Some(Duration.Zero))) should be (mockWebElement)
+
+    verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(200L, TimeUnit.MILLISECONDS)
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
+
+  }
+
+  "Attempt to locate existing element by javascript with 2 second timeout" should "return the element" in {
+
+    val locatorType = "javascript"
+    val lookup = "document.getElementById('username')"
+    val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
+    val locator = newLocator(None, mockWebDriver)
+
+    when(mockWebDriver.manage()).thenReturn(mockWebDriverOptions)
+    when(mockWebDriverOptions.timeouts()).thenReturn(mockWebDriverTimeouts)
+    doReturn(mockWebElement).when(mockWebDriver).executeScript(s"return $lookup")
+    when(mockWebElement.isDisplayed).thenReturn(true)
+
+    locator.locate(LocatorBinding("username", locatorType, lookup, None, Some(Duration.create(2, TimeUnit.SECONDS)))) should be (mockWebElement)
+
+    verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(2000L, TimeUnit.MILLISECONDS)
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
 
   }
   
@@ -133,7 +241,7 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
 
   }
   
-  private def shouldFindWebElement(locatorType: String, lookup: String, by: By) {
+  private def shouldFindWebElement(locatorType: String, lookup: String, by: By, timeout: Option[Duration]) {
 
     val env = newEnv
     val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
@@ -143,7 +251,7 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
     when(mockWebDriverOptions.timeouts()).thenReturn(mockWebDriverTimeouts)
     when(mockWebDriver.findElement(by)).thenReturn(mockWebElement)
     when(mockWebElement.isDisplayed).thenReturn(true)
-    
+
     when(mockWebDriver.findElement(By.id("container"))).thenReturn(mockContainerElement)
     when(mockContainerElement.getTagName).thenReturn("div")
     when(mockContainerElement.findElement(by)).thenReturn(mockWebElement)
@@ -164,12 +272,21 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
     env.scopes.set("frame/locator", "id")
     env.scopes.set("frame/locator/id", "frame")
 
-    locator.locate(LocatorBinding("username", locatorType, lookup, None)) should be (mockWebElement)
-    locator.locate(LocatorBinding("username", locatorType, lookup, Some("container"))) should be (mockWebElement)
-    locator.locate(LocatorBinding("username", locatorType, lookup, Some("iframe"))) should be (mockWebElement)
-    locator.locate(LocatorBinding("username", locatorType, lookup, Some("frame"))) should be (mockWebElement)
+    locator.locate(LocatorBinding("username", locatorType, lookup, None, timeout)) should be (mockWebElement)
+    locator.locate(LocatorBinding("username", locatorType, lookup, Some("container"), timeout)) should be (mockWebElement)
+    locator.locate(LocatorBinding("username", locatorType, lookup, Some("iframe"), timeout)) should be (mockWebElement)
+    locator.locate(LocatorBinding("username", locatorType, lookup, Some("frame"), timeout)) should be (mockWebElement)
     
     verify(mockWebDriver, times(3)).findElement(by)
+
+    timeout.foreach { t =>
+      val expectedTimeout = if(t == Duration.Zero) 200L else t.toMillis
+      verify(mockWebDriverTimeouts, times(4)).implicitlyWait(expectedTimeout, TimeUnit.MILLISECONDS)
+      verify(mockWebDriverTimeouts, times(4)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
+    }
+    if (timeout.isEmpty) {
+      verifyZeroInteractions(mockWebDriverTimeouts)
+    }
     
   }
   
@@ -211,35 +328,99 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
   }
 
   "Attempt to locate existing elements by id" should "return the elements" in {
-    shouldFindAllWebElements("id", "uname", By.id("uname"))
+    shouldFindAllWebElements("id", "uname", By.id("uname"), None)
+  }
+
+  "Attempt to locate existing elements by id with no wait" should "return the elements" in {
+    shouldFindAllWebElements("id", "uname", By.id("uname"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by id with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("id", "uname", By.id("uname"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by name" should "return the elements" in {
-    shouldFindAllWebElements("name", "uname", By.name("uname"))
+    shouldFindAllWebElements("name", "uname", By.name("uname"), None)
+  }
+
+  "Attempt to locate existing elements by name with no wait" should "return the elements" in {
+    shouldFindAllWebElements("name", "uname", By.name("uname"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by name with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("name", "uname", By.name("uname"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by tag name" should "return the elements" in {
-    shouldFindAllWebElements("tag name", "input", By.tagName("input"))
+    shouldFindAllWebElements("tag name", "input", By.tagName("input"), None)
+  }
+
+  "Attempt to locate existing elements by tag name with no wait" should "return the elements" in {
+    shouldFindAllWebElements("tag name", "input", By.tagName("input"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by tag name with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("tag name", "input", By.tagName("input"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by css selector" should "return the elements" in {
-    shouldFindAllWebElements("css selector", ":focus", By.cssSelector(":focus"))
+    shouldFindAllWebElements("css selector", ":focus", By.cssSelector(":focus"), None)
+  }
+
+  "Attempt to locate existing elements by css selector with no wait" should "return the elements" in {
+    shouldFindAllWebElements("css selector", ":focus", By.cssSelector(":focus"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by css selector with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("css selector", ":focus", By.cssSelector(":focus"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by xpath" should "return the elements" in {
-    shouldFindAllWebElements("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"))
+    shouldFindAllWebElements("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), None)
+  }
+
+  "Attempt to locate existing elements by xpath with no wait" should "return the elements" in {
+    shouldFindAllWebElements("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by xpath with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("xpath", "//input[name='uname']", By.xpath("//input[name='uname']"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by class name" should "return the elements" in {
-    shouldFindAllWebElements("class name", ".userinput", By.className(".userinput"))
+    shouldFindAllWebElements("class name", ".userinput", By.className(".userinput"), None)
+  }
+
+  "Attempt to locate existing elements by class name with no wait" should "return the elements" in {
+    shouldFindAllWebElements("class name", ".userinput", By.className(".userinput"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by class name with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("class name", ".userinput", By.className(".userinput"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by link text" should "return the elements" in {
-    shouldFindAllWebElements("link text", "User name", By.linkText("User name"))
+    shouldFindAllWebElements("link text", "User name", By.linkText("User name"), None)
+  }
+
+  "Attempt to locate existing elements by link text with no wait" should "return the elements" in {
+    shouldFindAllWebElements("link text", "User name", By.linkText("User name"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by link text with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("link text", "User name", By.linkText("User name"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by partial link text" should "return the elements" in {
-    shouldFindAllWebElements("partial link text", "User", By.partialLinkText("User"))
+    shouldFindAllWebElements("partial link text", "User", By.partialLinkText("User"), None)
+  }
+
+  "Attempt to locate existing elements by partial link text with no wait" should "return the elements" in {
+    shouldFindAllWebElements("partial link text", "User", By.partialLinkText("User"), Some(Duration.Zero))
+  }
+
+  "Attempt to locate existing elements by partial link text with 2 second wait" should "return the elements" in {
+    shouldFindAllWebElements("partial link text", "User", By.partialLinkText("User"), Some(Duration(2, TimeUnit.SECONDS)))
   }
 
   "Attempt to locate existing elements by javascript" should "return the elements" in {
@@ -261,6 +442,55 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
     locator.locateAll(LocatorBinding("username", locatorType, lookup, None)) should be (mockWebElements)
 
     verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verifyZeroInteractions(mockWebDriverTimeouts)
+
+  }
+
+  "Attempt to locate existing elements by javascript with no wait" should "return the elements" in {
+
+    val locatorType = "javascript"
+    val lookup = "document.getElementsByName('username')"
+    val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
+    val locator = newLocator(None, mockWebDriver)
+
+    val mockWebElementsArrayList = new java.util.ArrayList[WebElement]()
+    mockWebElementsArrayList.add(mockWebElements(0))
+    mockWebElementsArrayList.add(mockWebElements(1))
+
+    when(mockWebDriver.manage()).thenReturn(mockWebDriverOptions)
+    when(mockWebDriverOptions.timeouts()).thenReturn(mockWebDriverTimeouts)
+    doReturn(mockWebElementsArrayList).when(mockWebDriver).executeScript(s"return $lookup")
+    when(mockWebElement.isDisplayed).thenReturn(true)
+
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, None, Some(Duration.Zero))) should be (mockWebElements)
+
+    verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(200L, TimeUnit.MILLISECONDS)
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
+
+  }
+
+  "Attempt to locate existing elements by javascript with 2 second timeout" should "return the elements" in {
+
+    val locatorType = "javascript"
+    val lookup = "document.getElementsByName('username')"
+    val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
+    val locator = newLocator(None, mockWebDriver)
+
+    val mockWebElementsArrayList = new java.util.ArrayList[WebElement]()
+    mockWebElementsArrayList.add(mockWebElements(0))
+    mockWebElementsArrayList.add(mockWebElements(1))
+
+    when(mockWebDriver.manage()).thenReturn(mockWebDriverOptions)
+    when(mockWebDriverOptions.timeouts()).thenReturn(mockWebDriverTimeouts)
+    doReturn(mockWebElementsArrayList).when(mockWebDriver).executeScript(s"return $lookup")
+    when(mockWebElement.isDisplayed).thenReturn(true)
+
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, None, Some(Duration.create(2, TimeUnit.SECONDS)))) should be (mockWebElements)
+
+    verify(mockWebDriver, times(1)).executeScript(s"return $lookup")
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(2000L, TimeUnit.MILLISECONDS)
+    verify(mockWebDriverTimeouts, times(1)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
 
   }
 
@@ -283,7 +513,7 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
 
   }
 
-  private def shouldFindAllWebElements(locatorType: String, lookup: String, by: By) {
+  private def shouldFindAllWebElements(locatorType: String, lookup: String, by: By, timeout: Option[Duration]) {
 
     val env = newEnv
     val mockWebDriver: FirefoxDriver = mock[FirefoxDriver]
@@ -318,12 +548,21 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar {
     env.scopes.set("frame/locator", "id")
     env.scopes.set("frame/locator/id", "frame")
 
-    locator.locateAll(LocatorBinding("username", locatorType, lookup, None)) should be (mockWebElements)
-    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("container"))) should be (mockWebElements)
-    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("iframe"))) should be (mockWebElements)
-    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("frame"))) should be (mockWebElements)
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, None, timeout)) should be (mockWebElements)
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("container"), timeout)) should be (mockWebElements)
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("iframe"), timeout)) should be (mockWebElements)
+    locator.locateAll(LocatorBinding("username", locatorType, lookup, Some("frame"), timeout)) should be (mockWebElements)
 
     verify(mockWebDriver, times(3)).findElements(by)
+
+    timeout.foreach { t =>
+      val expectedTimeout = if(t == Duration.Zero) 200L else t.toMillis
+      verify(mockWebDriverTimeouts, times(4)).implicitlyWait(expectedTimeout, TimeUnit.MILLISECONDS)
+      verify(mockWebDriverTimeouts, times(4)).implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
+    }
+    if (timeout.isEmpty) {
+      verifyZeroInteractions(mockWebDriverTimeouts)
+    }
 
   }
 

--- a/src/test/scala/gwen/web/WebEngineTest.scala
+++ b/src/test/scala/gwen/web/WebEngineTest.scala
@@ -167,6 +167,7 @@ class WebEngineTest extends FlatSpec with WebEngine with Matchers with MockitoSu
     val mockBinding = mock[LocatorBinding]
     doReturn(mockBinding).when(env).getLocatorBinding("<container>")
     locators.foreach { locator =>
+      when(mockScopes.getOpt(s"<element>/locator/$locator/timeoutSecs")).thenReturn(None)
       evaluate(s"""<element> can be located by $locator "<value>" in <container>""")
       verify(mockScopes).set("<element>/locator", locator)
       verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
@@ -174,13 +175,63 @@ class WebEngineTest extends FlatSpec with WebEngine with Matchers with MockitoSu
     }
   }
 
+  """<element> can be located by <locator> "<value>" in <container> with no wait""" should "evaluate" in {
+    val mockBinding = mock[LocatorBinding]
+    doReturn(mockBinding).when(env).getLocatorBinding("<container>")
+    locators.foreach { locator =>
+      evaluate(s"""<element> can be located by $locator "<value>" in <container> with no wait""")
+      verify(mockScopes).set("<element>/locator", locator)
+      verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
+      verify(mockScopes).set(s"<element>/locator/$locator/container", "<container>")
+      verify(mockScopes).set(s"<element>/locator/$locator/timeoutSecs", "0")
+    }
+  }
+
+  """<element> can be located by <locator> "<value>" in <container> with <timeoutPeriod> second timeout""" should "evaluate" in {
+    val mockBinding = mock[LocatorBinding]
+    doReturn(mockBinding).when(env).getLocatorBinding("<container>")
+    locators.foreach { locator =>
+      evaluate(s"""<element> can be located by $locator "<value>" in <container> with 2 second timeout""")
+      verify(mockScopes).set("<element>/locator", locator)
+      verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
+      verify(mockScopes).set(s"<element>/locator/$locator/container", "<container>")
+      verify(mockScopes).set(s"<element>/locator/$locator/timeoutSecs", "2")
+    }
+  }
+
   """<element> can be located by <locator> "<value>"""" should "evaluate" in {
     locators.foreach { locator =>
       when(mockScopes.getOpt(s"<element>/locator/$locator/container")).thenReturn(Some("container"))
+      when(mockScopes.getOpt(s"<element>/locator/$locator/timeoutSecs")).thenReturn(Some("2"))
       evaluate(s"""<element> can be located by $locator "<value>"""")
       verify(mockScopes).set("<element>/locator", locator)
       verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
       verify(mockScopes).set(s"<element>/locator/$locator/container", null)
+      verify(mockScopes).set(s"<element>/locator/$locator/timeoutSecs", null)
+    }
+  }
+
+   """<element> can be located by <locator> "<value>" with no wait""" should "evaluate" in {
+    locators.foreach { locator =>
+      when(mockScopes.getOpt(s"<element>/locator/$locator/container")).thenReturn(Some("container"))
+      when(mockScopes.getOpt(s"<element>/locator/$locator/timeoutSecs")).thenReturn(Some("2"))
+      evaluate(s"""<element> can be located by $locator "<value>" with no wait""")
+      verify(mockScopes).set("<element>/locator", locator)
+      verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
+      verify(mockScopes).set(s"<element>/locator/$locator/container", null)
+      verify(mockScopes).set(s"<element>/locator/$locator/timeoutSecs", "0")
+    }
+  }
+
+  """<element> can be located by <locator> "<value>" with <timeoutPeriod> second timeout""" should "evaluate" in {
+    locators.foreach { locator =>
+      when(mockScopes.getOpt(s"<element>/locator/$locator/container")).thenReturn(Some("container"))
+      when(mockScopes.getOpt(s"<element>/locator/$locator/timeoutSecs")).thenReturn(Some("2"))
+      evaluate(s"""<element> can be located by $locator "<value>" with 2 second timeout""")
+      verify(mockScopes).set("<element>/locator", locator)
+      verify(mockScopes).set(s"<element>/locator/$locator", "<value>")
+      verify(mockScopes).set(s"<element>/locator/$locator/container", null)
+      verify(mockScopes).set(s"<element>/locator/$locator/timeoutSecs", "2")
     }
   }
 
@@ -1123,6 +1174,20 @@ class WebEngineTest extends FlatSpec with WebEngine with Matchers with MockitoSu
     step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>"""")
   }
 
+  """<step> for each <element> located by id "<expression>" with no wait""" should "evaluate" in {
+    doReturn(Nil).when(webContext).locateAll(any[LocatorBinding])
+    val step = evaluatePriority(s"""x is "1" for each <element> located by id "<expression>" with no wait""")
+    step should not be (None)
+    step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>" with no wait""")
+  }
+
+   """<step> for each <element> located by id "<expression>" with <timeoutPeriod> second timeout""" should "evaluate" in {
+    doReturn(Nil).when(webContext).locateAll(any[LocatorBinding])
+    val step = evaluatePriority(s"""x is "1" for each <element> located by id "<expression>" with 2 second timeout""")
+    step should not be (None)
+    step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>" with 2 second timeout""")
+  }
+
   """<step> for each <element> located by id "<expression>" in <container>""" should "evaluate" in {
     val mockBinding = mock[LocatorBinding]
     doReturn(mockBinding).when(env).getLocatorBinding("<container>")
@@ -1130,6 +1195,24 @@ class WebEngineTest extends FlatSpec with WebEngine with Matchers with MockitoSu
     val step = evaluatePriority(s"""x is "1" for each <element> located by id "<expression>" in <container>""")
     step should not be (None)
     step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>" in <container>""")
+  }
+
+  """<step> for each <element> located by id "<expression>" in <container> with no wait""" should "evaluate" in {
+    val mockBinding = mock[LocatorBinding]
+    doReturn(mockBinding).when(env).getLocatorBinding("<container>")
+    doReturn(Nil).when(webContext).locateAll(any[LocatorBinding])
+    val step = evaluatePriority(s"""x is "1" for each <element> located by id "<expression>" in <container> with no wait""")
+    step should not be (None)
+    step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>" in <container> with no wait""")
+  }
+
+  """<step> for each <element> located by id "<expression>" in <container> with <timeoutPeriod> second timeout""" should "evaluate" in {
+    val mockBinding = mock[LocatorBinding]
+    doReturn(mockBinding).when(env).getLocatorBinding("<container>")
+    doReturn(Nil).when(webContext).locateAll(any[LocatorBinding])
+    val step = evaluatePriority(s"""x is "1" for each <element> located by id "<expression>" in <container> with 2 second timeout""")
+    step should not be (None)
+    step.get.toString should be (s"""Given x is "1" for each <element> located by id "<expression>" in <container> with 2 second timeout""")
   }
 
   "<step> for each <element> in <elements>" should "evaluate" in {

--- a/src/test/scala/gwen/web/WebEnvContextTest.scala
+++ b/src/test/scala/gwen/web/WebEnvContextTest.scala
@@ -17,10 +17,8 @@
 package gwen.web
 
 import gwen.{Settings, UserOverrides}
-import org.mockito.Mockito.when
 import org.mockito.Mockito.verify
-import org.mockito.Matchers.any
-import org.openqa.selenium.{TimeoutException, WebDriver}
+import org.openqa.selenium.WebDriver
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.mockito.MockitoSugar


### PR DESCRIPTION
Locator Level Timeouts
------------------------
The PR adds support for specifying timeouts (implicit waits) for individual locators to allow the default or configured global timeout (`gwen.web.wait.seconds`) to be overridden. This is useful for cases where you may want to increase the locator timeout period for some web elements without impacting others. A web element that takes a long time to load for example can have a higher locator timeout  without slowing down the rest of your locators.

The following DSLs are introduced to support this:
  - `<element> can be located by <locator> "<expression>" with no wait`
  - `<element> can be located by <locator> "<expression>" with <timeoutPeriod> second timeout`
  - `<element> can be located by <locator> "<expression>" in <container> with no wait`
  - `<element> can be located by <locator> "<expression>" in <container> with <timeoutPeriod> second timeout`
  - `<step> for each <element> located by <locator> "<expression>" with no wait`
  - `<step> for each <element> located by <locator> "<expression>" with <timeoutPeriod> second timeout`
  - `<step> for each <element> located by <locator> "<expression>" in <container> with no wait`
  - `<step> for each <element> located by <locator> "<expression>" in <container> with <timeoutPeriod> second timeout`
  - ```
    <element> can be located with no wait by
      | locator 1  | expression 1  |
      | locator 2  | expression 2  |
      | locator .. | expression .. |
      | locator N  | expression N  |
    ```
    - Where
      - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
      - column 2 = the lookup expression literal
  - ```
     <element> can be located with <timeoutPeriod> second timeout by
      | locator 1  | expression 1  |
      | locator 2  | expression 2  |
      | locator .. | expression .. |
      | locator N  | expression N  |
    ```
    - Where
      - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
      - column 2 = the lookup expression literal

Existing locator DSL's are not impacted.

### Examples
```
# will cause lookup to fail immediately if username is not present on the page
And the username can be located by id "username" with no wait

# will cause lookup to fail if the username is not available on the page after waiting 20 seconds
And the username can be located by id "username" with 20 second timeout

# will cause lookup to fail if the username is not available on the page after configured wait time (default behaviour)
And the username can be located by id "username"
```