### PR TITLE
Implicit JavaScript Locators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,12 @@ Apr 29, 2018
     - Where
       - column 1 = id|name|tag name|css selector|xpath|class name|link text|partial link text|javascript
       - column 2 = the lookup expression literal
+- Add `gwen.web.implicit.js.locators` setting to enable Gwen to implicitly convert all locator bindings to JavaScript
+  equivalents and force all elements to be located by executing javascript on the page instead of looking them up
+  using web driver locators. Enabling this is useful when dealing with web sites that dynamically render or change
+  the visibility of elements on pages or manipulate the DOM. Value values are:
+  - `false` to disable (default)
+  - `false` to enable
 
 2.18.0
 ======

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ functions on pages may be necessary.
 
 ### What's New?
 
+- [Implicit JavaScript Locators](https://github.com/gwen-interpreter/gwen-web/wiki/Implicit-JavaScript-Locators)
 - [Locator level timeouts](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Level-Timeouts)
 - [Append text to fields](https://github.com/gwen-interpreter/gwen-web/wiki/Supported-DSL#i-append-value-in-element)
-- [Drag and Drop](https://github.com/gwen-interpreter/gwen-web/wiki/Supported-DSL#i-drag-and-drop-sourceelement-to-targetelement)
 
 Why Gwen-web?
 -------------
@@ -98,6 +98,7 @@ Key Features
 - [Headless Browser Execution](https://github.com/gwen-interpreter/gwen-web/wiki/Runtime-Settings#gwenwebbrowserheadless)
 - [Gwen Workspaces](https://gweninterpreter.wordpress.com/2017/12/18/gwen-workspaces/) for easy and consistent Gwen installation, configuration and execution on any workstation or build server.
 - [Locator level timeouts](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Level-Timeouts)
+- [Implicit JavaScript Locators](https://github.com/gwen-interpreter/gwen-web/wiki/Implicit-JavaScript-Locators)
 
 Quick Links to Wiki Information
 -------------------------------

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ functions on pages may be necessary.
 
 ### What's New?
 
+- [Locator level timeouts](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Level-Timeouts)
 - [Append text to fields](https://github.com/gwen-interpreter/gwen-web/wiki/Supported-DSL#i-append-value-in-element)
 - [Drag and Drop](https://github.com/gwen-interpreter/gwen-web/wiki/Supported-DSL#i-drag-and-drop-sourceelement-to-targetelement)
-- [Template matching](https://github.com/gwen-interpreter/gwen/wiki/Template-Matching)
 
 Why Gwen-web?
 -------------
@@ -97,6 +97,7 @@ Key Features
 - [Locator Chaining](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Chaining)
 - [Headless Browser Execution](https://github.com/gwen-interpreter/gwen-web/wiki/Runtime-Settings#gwenwebbrowserheadless)
 - [Gwen Workspaces](https://gweninterpreter.wordpress.com/2017/12/18/gwen-workspaces/) for easy and consistent Gwen installation, configuration and execution on any workstation or build server.
+- [Locator level timeouts](https://github.com/gwen-interpreter/gwen-web/wiki/Locator-Level-Timeouts)
 
 Quick Links to Wiki Information
 -------------------------------

--- a/src/main/scala/gwen/web/WebContext.scala
+++ b/src/main/scala/gwen/web/WebContext.scala
@@ -143,11 +143,8 @@ class WebContext(env: WebEnvContext, driverManager: DriverManager) extends WebEl
               } catch {
                 case se: StaleElementReferenceException =>
                   Thread.sleep(WebSettings.`gwen.web.throttle.msecs`)
-                  // try js equivalent locator (if one can be derived)
-                  val elem = elementBinding.jsEquivalent match {
-                    case Some(jsBinding) => Try(locate(jsBinding)).getOrElse(locate(elementBinding))
-                    case None => locate(elementBinding)
-                  }
+                  // try js equivalent locator
+                  val elem = Try(locate(elementBinding.jsEquivalent)).getOrElse(locate(elementBinding))
                   operation(elem)
               }
           }

--- a/src/main/scala/gwen/web/WebEnvContext.scala
+++ b/src/main/scala/gwen/web/WebEnvContext.scala
@@ -18,6 +18,8 @@ package gwen.web
 
 import java.util.concurrent.TimeUnit
 
+import gwen.GwenSettings
+
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -163,7 +165,14 @@ class WebEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) exten
                   if (optional) None else locatorBindingError(element, s"locator lookup binding not found: $lookupBinding")
               }
             }
-            if (locators.nonEmpty) Some(LocatorBinding(element, locators.toList))
+            if (locators.nonEmpty) {
+              val locatorBinding = LocatorBinding(element, locators.toList)
+              if (WebSettings.`gwen.web.implicit.js.locators`) {
+                Some(locatorBinding.jsEquivalent)
+              } else {
+                Some(locatorBinding)
+              }
+            }
             else None
           case None => if (optional) None else locatorBindingError(element, s"locator binding not found: $locatorBinding")
         }

--- a/src/main/scala/gwen/web/WebSettings.scala
+++ b/src/main/scala/gwen/web/WebSettings.scala
@@ -159,4 +159,11 @@ object WebSettings {
    */
   def `gwen.web.capabilities`: Map[String, String] = Settings.findAllMulti("gwen.web.capabilities", "gwen.web.capability")
 
+  /**
+    * Provides access to the `gwen.web.implicit.js.locators` setting used to determine whether or not Gwen should
+    * implicitly convert all locator bindings to JavaScript equivalents to force all elements to be located by
+    * executing javascript on the page. Default value is false.
+    */
+  def `gwen.web.implicit.js.locators`: Boolean = Settings.getOpt("gwen.web.implicit.js.locators").getOrElse("false").toBoolean
+
 }

--- a/src/test/scala/gwen/web/WebElementLocatorTest.scala
+++ b/src/test/scala/gwen/web/WebElementLocatorTest.scala
@@ -19,7 +19,6 @@ package gwen.web
 import java.util.concurrent.TimeUnit
 
 import org.mockito.Mockito.atLeastOnce
-import org.mockito.Mockito.never
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -41,6 +40,9 @@ import org.mockito.Matchers.{anyVararg, same}
 import scala.concurrent.duration.Duration
 
 class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  // disable implicit js locators for unit test
+  sys.props += (("gwen.web.implicit.js.locators", "false"))
 
   private var mockWebElement: WebElement = _
   private var mockWebElements: List[WebElement] = _
@@ -647,48 +649,119 @@ class WebElementLocatorTest extends FlatSpec with Matchers with MockitoSugar wit
 
   }
 
-  "Locator bindings with JS equivalents" should "resolve" in {
+  "Single element locator bindings with JS equivalents" should "resolve" in {
 
     val container = Some("container")
 
     LocatorBinding("user name", "id", "username", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.getElementById('username')", None))
+     LocatorBinding("user name", "javascript", "document.getElementById('username')", None)
     }
     LocatorBinding("user name", "id", "username", container).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.getElementById('username')", None))
+     LocatorBinding("user name", "javascript", "document.getElementById('username')", container)
     }
     LocatorBinding("user name", "name", "username", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.getElementsByName('username')[0]", None))
+     LocatorBinding("user name", "javascript", "document.getElementsByName('username')[0]", None)
+    }
+    LocatorBinding("user name", "name", "username", container).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", "document.getElementsByName('username')[0]", container)
     }
     LocatorBinding("user name", "class name", "username", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.getElementsByClassName('username')[0]", None))
+     LocatorBinding("user name", "javascript", "document.getElementsByClassName('username')[0]", None)
+    }
+    LocatorBinding("user name", "class name", "username", container).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", "document.getElementsByClassName('username')[0]", container)
     }
     LocatorBinding("user name", "css selector", ".username", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.querySelector('.username')", None))
+     LocatorBinding("user name", "javascript", "document.querySelector('.username')", None)
+    }
+    LocatorBinding("user name", "css selector", ".username", container).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", "document.querySelector('.username')", container)
     }
     LocatorBinding("user name", "tag name", "input", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.getElementsByTagName('input')[0]", None))
+     LocatorBinding("user name", "javascript", "document.getElementsByTagName('input')[0]", None)
+    }
+    LocatorBinding("user name", "tag name", "input", container).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", "document.getElementsByTagName('input')[0]", container)
     }
     LocatorBinding("user name", "xpath", "//html/body/div/input", None).jsEquivalent should be {
-      Some(LocatorBinding("user name", "javascript", "document.evaluate('//html/body/div/input', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue", None))
+     LocatorBinding("user name", "javascript", """document.evaluate('\/\/html\/body\/div\/input', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue""", None)
+    }
+    LocatorBinding("user link", "link text", "user", None).jsEquivalent should be {
+     LocatorBinding("user link", "javascript", """document.evaluate('//a[text()="user"]'), document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue""", None)
+    }
+    LocatorBinding("user link", "link text", "user", container).jsEquivalent should be {
+     LocatorBinding("user link", "javascript", """document.evaluate('//a[text()="user"]'), document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue""", container)
+    }
+    LocatorBinding("user link", "partial link text", "user", None).jsEquivalent should be {
+     LocatorBinding("user link", "javascript", """document.evaluate('//a[contains(text(), "user")]'), document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue""", None)
+    }
+    LocatorBinding("user link", "partial link text", "user", container).jsEquivalent should be {
+     LocatorBinding("user link", "javascript", """document.evaluate('//a[contains(text(), "user")]'), document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue""", container)
+    }
+    LocatorBinding("user name", "javascript", "document.getElementById('user')", None).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", """document.getElementById('user')""", None)
+    }
+    LocatorBinding("user name", "javascript", "document.getElementById('user')", container).jsEquivalent should be {
+     LocatorBinding("user name", "javascript", """document.getElementById('user')""", container)
     }
 
   }
 
-  "Locator bindings without JS equivalents" should "not resolve" in {
+  "Multi element locator bindings with JS equivalents" should "resolve" in {
 
     val container = Some("container")
 
-    LocatorBinding("user name", "name", "username", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "class name", "username", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "css selector", ".username", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "tag name", "input", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "xpath", "//html/body/div/input", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "link text", "user name", None).jsEquivalent should be (None)
-    LocatorBinding("user name", "link text", "username", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "partial link text", "user name", None).jsEquivalent should be (None)
-    LocatorBinding("user name", "partial link text", "username", container).jsEquivalent should be (None)
-    LocatorBinding("user name", "javascript", "document.getElementById('username')", container).jsEquivalent should be (None)
+    LocatorBinding("user name/list", "id", "username", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.querySelectorAll('#username')", None)
+    }
+    LocatorBinding("user name/list", "id", "username", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.querySelectorAll('#username')", container)
+    }
+    LocatorBinding("user name/list", "name", "username", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByName('username')", None)
+    }
+    LocatorBinding("user name/list", "name", "username", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByName('username')", container)
+    }
+    LocatorBinding("user name/list", "class name", "username", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByClassName('username')", None)
+    }
+    LocatorBinding("user name/list", "class name", "username", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByClassName('username')", container)
+    }
+    LocatorBinding("user name/list", "css selector", ".username", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.querySelectorAll('.username')", None)
+    }
+    LocatorBinding("user name/list", "css selector", ".username", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.querySelectorAll('.username')", container)
+    }
+    LocatorBinding("user name/list", "tag name", "input", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByTagName('input')", None)
+    }
+    LocatorBinding("user name/list", "tag name", "input", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", "document.getElementsByTagName('input')", container)
+    }
+    LocatorBinding("user name/list", "xpath", "//html/body/div/input", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", """document.evaluate('\/\/html\/body\/div\/input', document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null)""", None)
+    }
+    LocatorBinding("user link/list", "link text", "user", None).jsEquivalent should be {
+     LocatorBinding("user link/list", "javascript", """document.evaluate('//a[text()="user"]'), document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null)""", None)
+    }
+    LocatorBinding("user link/list", "link text", "user", container).jsEquivalent should be {
+     LocatorBinding("user link/list", "javascript", """document.evaluate('//a[text()="user"]'), document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null)""", container)
+    }
+    LocatorBinding("user link/list", "partial link text", "user", None).jsEquivalent should be {
+     LocatorBinding("user link/list", "javascript", """document.evaluate('//a[contains(text(), "user")]'), document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null)""", None)
+    }
+    LocatorBinding("user link/list", "partial link text", "user", container).jsEquivalent should be {
+     LocatorBinding("user link/list", "javascript", """document.evaluate('//a[contains(text(), "user")]'), document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null)""", container)
+    }
+    LocatorBinding("user name/list", "javascript", "document.getElementsByName('user')", None).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", """document.getElementsByName('user')""", None)
+    }
+    LocatorBinding("user name/list", "javascript", "document.getElementsByName('user')", container).jsEquivalent should be {
+     LocatorBinding("user name/list", "javascript", """document.getElementsByName('user')""", container)
+    }
 
   }
   

--- a/src/test/scala/gwen/web/features/IframeFeatureTest.scala
+++ b/src/test/scala/gwen/web/features/IframeFeatureTest.scala
@@ -1,6 +1,6 @@
 package gwen.web.features
 
-class WebInterpreterSwitchToDefaultContentTest extends BaseFeatureTest {
+class SwitchToDefaultContentTest extends BaseFeatureTest {
   "Locator Chaining feature" should "should evaluate" in {
     evaluate(List("features/locators-chaining"), parallel = false, dryRun = false, "target/reports/locators-chainings", None)
   }


### PR DESCRIPTION
Implicit JavaScript Locators
----------------------------

This PR introduces the `gwen.web.implicit.js.locators` setting to enable Gwen to implicitly convert all locator bindings to JavaScript equivalents and force all elements to be located by executing javascript on the page instead of looking them up using web driver locator mechanism. Enabling this is useful when dealing with web sites that dynamically render or change the visibility of elements on pages or manipulate the DOM. Value values are:
  - `false` to disable (default)
  - `true` to enable

### How does it work?

Say you define a locator in Gwen to lookup a user name field by ID as follows:

`Given user name can be located by id "username"`

Gwen will normally lookup this field using the "By.Id locator" mechanism of web driver. This is the default Gwen behaviour when the `gwen.web.implicit.js.locators` setting is not set or is set to `false`.

Now if you set the `gwen.web.implicit.js.locators` setting to `true`, Gwen will internally create a JavaScript equivalent locator for the above (and all other locator bindings you have defined) and physically execute that script on the page to locate the element instead of performing the standard web driver lookup. It will do this without you having to rewrite any of your existing locator bindings. In the case of the above example, it would run `document.getElementById("username")` on the web page.

All the standard locators (id, name, css selector, class name, tag name, xpath, etc..) will be implicity converted to their JavaScript equivalents when this setting is enabled. So you don't have to rewrite your existing locator binding definitions if you decide that you want them all to run as JavaScript. Any explicitly defined JavaScript bindings you may have will execute unchanged. 

### Try it

The feature is available in the following snapshot if you want to try it out:
- [gwen-web;2.18.0-7-g549c311-SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/org/gweninterpreter/gwen-web/2.18.0-7-g549c311-SNAPSHOT)