### PR TITLE
Add Gwen settings to override path to Chrome and Firefox binaries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.44.0
+======
+September 19, 2020
+- Add settings `gwen.web.chrome.path` and `gwen.web.firefox.path` to override
+  the browser binary path
+
 2.43.0
 ======
 July 14, 2020

--- a/src/main/scala/gwen/web/DriverManager.scala
+++ b/src/main/scala/gwen/web/DriverManager.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015-2019 Brady Wood, Branko Juric
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ class DriverManager extends LazyLogging {
   if (sys.props.get("wdm.targetPath").isEmpty) {
     sys.props += (("wdm.targetPath", new File(new File(System.getProperty("user.home")), ".gwen/wdm").getAbsolutePath))
   }
-    
+
   /** Map of web driver instances (keyed by name). */
   private[web] val drivers: mutable.Map[String, WebDriver] = mutable.Map()
 
@@ -58,7 +58,7 @@ class DriverManager extends LazyLogging {
 
   /** Current stack of windows (per session). */
   private val windows = mutable.Map[String, List[String]]()
-    
+
   /** Provides private access to the web driver */
   private def webDriver: WebDriver = drivers.getOrElse(session, {
       loadWebDriver tap { driver =>
@@ -95,7 +95,7 @@ class DriverManager extends LazyLogging {
     * @param f the function to perform
     */
   def withWebDriver[T](f: WebDriver => T): T = f(webDriver)
-  
+
   /** Loads the selenium webdriver. */
   private[web] def loadWebDriver: WebDriver = withGlobalSettings {
     (WebSettings.`gwen.web.remote.url` match {
@@ -111,7 +111,7 @@ class DriverManager extends LazyLogging {
       }
     }
   }
-  
+
   private def remoteDriver(addr: String): WebDriver = {
     val capSettings = WebSettings.`gwen.web.capabilities`
     val browser = capSettings.get("browserName").orElse(capSettings.get("browser")).orElse(capSettings.get("device")).getOrElse(WebSettings.`gwen.web.browser`)
@@ -130,13 +130,13 @@ class DriverManager extends LazyLogging {
     logger.info(s"Starting remote $browser session${ if(session == "primary") "" else s": $session"}")
     remote(addr, capabilities)
   }
-  
+
   /**
     * Gets the local web driver for the given name.
-    * 
+    *
     *  @param driverName the name of the driver to get
     *  @throws gwen.web.errors.UnsupportedWebDriverException if the given
-    *          web driver name is unsupported 
+    *          web driver name is unsupported
     */
   private def localDriver(driverName: String): WebDriver = {
     logger.info(s"Starting $driverName browser session${ if(session == "primary") "" else s": $session"}")
@@ -149,7 +149,7 @@ class DriverManager extends LazyLogging {
       case _ => unsupportedWebDriverError(driverName)
     }
   }
-  
+
   private def firefoxOptions() : FirefoxOptions = {
     val firefoxProfile = new FirefoxProfile() tap { profile =>
       WebSettings.`gwen.web.firefox.prefs` foreach { case (name, value) =>
@@ -185,14 +185,18 @@ class DriverManager extends LazyLogging {
     }
     new FirefoxOptions()
       .setProfile(firefoxProfile) tap { options =>
-      if (WebSettings.`gwen.web.browser.headless`) {
-        logger.info(s"Setting firefox argument: -headless")
-        options.addArguments("-headless")
+        if (WebSettings.`gwen.web.browser.headless`) {
+          logger.info(s"Setting firefox argument: -headless")
+          options.addArguments("-headless")
+        }
+        WebSettings.`gwen.web.firefox.path` foreach { path =>
+          logger.info(s"Setting firefox path: $path")
+          options.setBinary(path)
+        }
+        setDesiredCapabilities(options)
       }
-      setDesiredCapabilities(options)
-    }
   }
-  
+
   private def chromeOptions() : ChromeOptions = new ChromeOptions() tap { options =>
     WebSettings.`gwen.web.useragent` foreach { agent =>
       logger.info(s"Setting chrome argument: --user-agent=$agent")
@@ -200,12 +204,16 @@ class DriverManager extends LazyLogging {
     }
     if (WebSettings.`gwen.web.authorize.plugins`) {
       logger.info("Setting chrome argument: --always-authorize-plugins")
-      options.addArguments("--always-authorize-plugins") 
+      options.addArguments("--always-authorize-plugins")
     }
     options.addArguments("--test-type")
     if (WebSettings.`gwen.web.accept.untrusted.certs`) {
       logger.info("Setting chrome argument: --ignore-certificate-errors")
       options.addArguments("--ignore-certificate-errors")
+    }
+    WebSettings.`gwen.web.chrome.path` foreach { path =>
+      logger.info(s"Setting chrome path: $path")
+      options.setBinary(path)
     }
     WebSettings.`gwen.web.chrome.args` foreach { arg =>
       logger.info(s"Setting chrome argument: $arg")
@@ -261,7 +269,7 @@ class DriverManager extends LazyLogging {
   private def ieOptions(): InternetExplorerOptions = new InternetExplorerOptions() tap { options =>
     def caps = setDesiredCapabilities(options)
     setDefaultCapability("requireWindowFocus", true, options)
-    setDefaultCapability("nativeEvents", false, options);    
+    setDefaultCapability("nativeEvents", false, options);
     setDefaultCapability("unexpectedAlertBehaviour", "accept", options);
     setDefaultCapability("ignoreProtectedModeSettings", true, options);
     setDefaultCapability("disable-popup-blocking", true, options);
@@ -303,21 +311,21 @@ class DriverManager extends LazyLogging {
         else capabilities.setCapability(name, strValue)
     }
   }
-  
+
   private[web] def chrome(): WebDriver = {
-    if (WebSettings.`webdriver.chrome.driver`.isEmpty) { 
+    if (WebSettings.`webdriver.chrome.driver`.isEmpty) {
       WebDriverManager.chromedriver().setup()
     }
     new ChromeDriver(chromeOptions())
   }
-  
+
   private[web] def firefox(): WebDriver = {
     if (WebSettings.`webdriver.gecko.driver`.isEmpty) {
       WebDriverManager.firefoxdriver().setup()
     }
     new FirefoxDriver(firefoxOptions())
   }
-  
+
   private[web] def ie(): WebDriver = {
     if (WebSettings.`webdriver.ie.driver`.isEmpty) {
       WebDriverManager.iedriver().setup()
@@ -331,14 +339,14 @@ class DriverManager extends LazyLogging {
     }
     new EdgeDriver(edgeOptions())
   }
-  
+
   private[web] def safari(): WebDriver = {
     new SafariDriver(safariOptions())
   }
-  
+
   private[web] def remote(hubUrl: String, capabilities: DesiredCapabilities): WebDriver =
     new RemoteWebDriver(new HttpCommandExecutor(new URL(hubUrl)), capabilities)
-  
+
   private def withGlobalSettings(driver: WebDriver): WebDriver = {
     logger.info(s"Implicit wait (default locator timeout) = ${WebSettings.`gwen.web.locator.wait.seconds`} second(s)")
     driver.manage().timeouts().implicitlyWait(WebSettings.`gwen.web.locator.wait.seconds`, TimeUnit.SECONDS)
@@ -466,5 +474,5 @@ class DriverManager extends LazyLogging {
     windows += (session -> sWindows.tail)
     sWindows.head
   }
-  
+
 }

--- a/src/main/scala/gwen/web/WebSettings.scala
+++ b/src/main/scala/gwen/web/WebSettings.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015-2019 Brady Wood, Branko Juric
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ import gwen.errors.invalidSettingError
 import scala.util.Try
 
 /**
-  * Provides access to gwen web settings defined through system properties loaded 
+  * Provides access to gwen web settings defined through system properties loaded
   * from properties files.
   *
   * @author Branko Juric
@@ -43,31 +43,31 @@ object WebSettings {
 
   /** Edge driver setting. */
   def `webdriver.edge.driver`: Option[String] = Settings.getOpt("webdriver.edge.driver")
-  
+
   /**
-    * Provides access to the `gwen.web.browser` setting used to set the target browser 
+    * Provides access to the `gwen.web.browser` setting used to set the target browser
     * (default value is `chrome`). Valid values include chrome, firefox, safari, ie, and edge
     */
-  def `gwen.web.browser`: String = 
+  def `gwen.web.browser`: String =
     Settings.getOpt("gwen.web.browser").getOrElse("chrome")
-  
+
   /**
-    * Provides access to the `gwen.web.useragent` setting used to set the user agent header 
+    * Provides access to the `gwen.web.useragent` setting used to set the user agent header
     * in the browser (currently only supported for firefox and chrome).
     */
   def `gwen.web.useragent`: Option[String] = Settings.getOpt("gwen.web.useragent")
-  
+
   /**
    * If set, allows gwen-web to connect to a remote webdriver.
    */
   def `gwen.web.remote.url`: Option[String] = Settings.getOpt("gwen.web.remote.url")
-  
+
   /**
-    * Provides access to the `gwen.authorize.plugins` setting used to control whether 
+    * Provides access to the `gwen.authorize.plugins` setting used to control whether
     * or not the browser should authorize browser plugins. (default value is `false`).
     */
   def `gwen.web.authorize.plugins`: Boolean = Settings.getOpt("gwen.web.authorize.plugins").getOrElse("false").toBoolean
-  
+
   /**
     * Provides access to the `gwen.web.wait.seconds` setting used to set the implicit
     * timeout/wait time in the web driver (default is 10 seconds). This value is also used as the default for
@@ -80,28 +80,28 @@ object WebSettings {
     * locator wait/timeout time in the web driver (default is `gwen.web.wait.seconds` seconds).
     */
   def `gwen.web.locator.wait.seconds`: Long = Settings.getOpt("gwen.web.locator.wait.seconds").map(_.toLong).getOrElse(`gwen.web.wait.seconds`)
-  
+
   /**
-    * Provides access to the `gwen.web.maximize` setting used to control whether 
+    * Provides access to the `gwen.web.maximize` setting used to control whether
     * or not the web driver should maximize the browser window (default value is `false`).
     */
   def `gwen.web.maximize`: Boolean = Settings.getOpt("gwen.web.maximize").getOrElse("false").toBoolean
-  
+
   /**
-    * Provides access to the `gwen.web.throttle.msecs` setting used to control the wait 
-    * between javascript evaluations and duration of element highlighting (default value 
+    * Provides access to the `gwen.web.throttle.msecs` setting used to control the wait
+    * between javascript evaluations and duration of element highlighting (default value
     * is 100 msecs).
     */
   def `gwen.web.throttle.msecs`: Long = Settings.getOpt("gwen.web.throttle.msecs").getOrElse("100").toLong
-  
+
   /**
     * Provides access to the `gwen.web.highlight.style` setting used to control how
     * elements are highlighted (default value is `background: yellow; border: 2px solid gold;`).
     */
   def `gwen.web.highlight.style`: String = Settings.getOpt("gwen.web.highlight.style").getOrElse("background: yellow; border: 2px solid gold;")
-  
+
   /**
-    * Provides access to the `gwen.web.capture.screenshots` setting used to control whether 
+    * Provides access to the `gwen.web.capture.screenshots` setting used to control whether
     * or not the web driver should capture screenshots for all steps (default value is `false`).
     * Note that setting this to `true` degrades performance significantly. If the setting is true,
     * then the `gwen.report.slideshow.create` setting is also implicitly set to true so that the
@@ -110,45 +110,53 @@ object WebSettings {
   def `gwen.web.capture.screenshots`: Boolean = Settings.getOpt("gwen.web.capture.screenshots").getOrElse("false").toBoolean tap { isSet =>
     if (isSet) Settings.set("gwen.report.slideshow.create", "true")
   }
-  
+
   /**
-    * Provides access to the `gwen.web.capture.screenshots.highlighting` setting used to control whether 
-    * or not the web driver should capture screenshots for all steps that highlight elements on a page 
+    * Provides access to the `gwen.web.capture.screenshots.highlighting` setting used to control whether
+    * or not the web driver should capture screenshots for all steps that highlight elements on a page
     * (default value is `false`).
     * Note that setting this to `true` degrades performance significantly.
     */
   def `gwen.web.capture.screenshots.highlighting`: Boolean = Settings.getOpt("gwen.web.capture.screenshots.highlighting").getOrElse("false").toBoolean
-  
+
   /**
-    * Provides access to the `gwen.web.accept.untrusted.certs` setting used to control whether 
+    * Provides access to the `gwen.web.accept.untrusted.certs` setting used to control whether
     * or not the web driver should accept untrusted (self signed) SSL certificates (default value
     * is `true`).
     */
   def `gwen.web.accept.untrusted.certs`: Boolean = Settings.getOpt("gwen.web.accept.untrusted.certs").getOrElse("true").toBoolean
-  
+
   /**
-    * Provides access to the `gwen.web.suppress.images` setting used to control whether 
+    * Provides access to the `gwen.web.suppress.images` setting used to control whether
     * or not image rendering will be suppressed in the browser (default value
     * is `false`). Currently this capability is only supported in firefox driver.
     */
   def `gwen.web.suppress.images`: Boolean = Settings.getOpt("gwen.web.suppress.images").getOrElse("false").toBoolean
 
   /**
-   * Provides access to the `gwen.web.chrome.extensions` settings use to set 
+   * Provides access to the `gwen.web.chrome.extensions` settings use to set
    * the list of Chrome web browser extensions to load (default is empty list).
    * The settings accepts a comma separated list of paths to extensions (.crx files
    * or location paths). Each extension provided is loaded into the Chrome web driver.
    */
   def `gwen.web.chrome.extensions`: List[File] = Settings.getOpt("gwen.web.chrome.extensions").map(_.split(",").toList.map(_.trim)).getOrElse(Nil).map(new File(_))
-  
+
   /**
-    * Provides access to the `gwen.web.capture.screenshots.duplicates` setting used to control whether 
-    * or not the web driver should capture or discard contiguously duplicate screenshots 
-    * (default value is `false` ~ to discard). If set to `false`, then a screenshot will be discarded 
+    * Provides access to the `gwen.web.capture.screenshots.duplicates` setting used to control whether
+    * or not the web driver should capture or discard contiguously duplicate screenshots
+    * (default value is `false` ~ to discard). If set to `false`, then a screenshot will be discarded
     * if its size in bytes matches that of the last captured screenshot.
     */
   def `gwen.web.capture.screenshots.duplicates`: Boolean = Settings.getOpt("gwen.web.capture.screenshots.duplicates").getOrElse("false").toBoolean
-  
+
+  /**
+    * Provides access to the `gwen.web.chrome.path` setting used to specify the
+    * path to the Chrome browser binary. If not set, chromedriver will use the
+    * default system Chrome install. On macOS, this should be the actual binary,
+    * not just the app (e.g., `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`).
+    */
+  def `gwen.web.chrome.path`: Option[String] = Settings.getOpt("gwen.web.chrome.path")
+
   /**
    * Provides access to the `gwen.web.chrome.args` setting used to set
    * the list of Chrome web driver arguments to load (default is empty list).
@@ -157,13 +165,21 @@ object WebSettings {
    * List of chrome arguments: https://peter.sh/experiments/chromium-command-line-switches
    */
   def `gwen.web.chrome.args`: List[String] = Settings.findAllMulti("gwen.web.chrome.args")
-  
+
   /**
    * Provides access to the chrome preference settings. This setting merges a comma separated list of preferences
    * set in the `gwen.web.chrome.prefs` property with all properties that start with `gwen.web.chrome.pref.`.
    * List of chrome prefs: https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc
    */
   def `gwen.web.chrome.prefs`: Map[String, String] = Settings.findAllMulti("gwen.web.chrome.prefs", "gwen.web.chrome.pref")
+
+  /**
+    * Provides access to the `gwen.web.firefox.path` setting used to specify the
+    * path to the Firefox browser binary. If not set, geckodriver will use the
+    * default system Firefox install. On macOS, this should be the actual binary,
+    * not just the app (e.g, `/Applications/Firefox.app/Contents/MacOS/firefox`).
+    */
+  def `gwen.web.firefox.path`: Option[String] = Settings.getOpt("gwen.web.firefox.path")
 
   /**
    * Provides access to the firefox preference settings. This setting merges a comma separated list of preferences


### PR DESCRIPTION
Added the `gwen.web.chrome.path` and `gwen.web.firefox.path` to override the path to the Chrome and Firefox browser binaries, respectively.

Of note for macOS users - these properties need to point at the actual binary itself, and not just the `.app` bundle, according to [ChromeDriver documentation](https://chromedriver.chromium.org/capabilities#TOC-ChromeOptions-object). For example, with Chrome, setting `gwen.web.chrome.path` to `/Applications/Google Chrome.app` won't work - it needs to be set to `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`. I assume it's the same for Firefox and GeckoDriver, but I haven't been able to test.